### PR TITLE
Append lustre in front of metric name

### DIFF
--- a/src/brw_stats.rs
+++ b/src/brw_stats.rs
@@ -6,127 +6,127 @@ use prometheus_exporter_base::{prelude::*, Yes};
 use crate::{jobstats::build_ost_job_stats, Metric, StatsMapExt, ToMetricInst};
 
 static DISK_IO_TOTAL: Metric = Metric {
-    name: "disk_io_total",
+    name: "lustre_disk_io_total",
     help: "Total number of operations the filesystem has performed for the given size.",
     r#type: MetricType::Counter,
 };
 
 static DISK_IO_FRAGS: Metric = Metric {
-    name: "dio_frags",
+    name: "lustre_dio_frags",
     help: "Current disk IO fragmentation for the given size.",
     r#type: MetricType::Gauge,
 };
 
 static DISK_IO: Metric = Metric {
-    name: "disk_io",
+    name: "lustre_disk_io",
     help: "Current number of I/O operations that are processing during the snapshot.",
     r#type: MetricType::Gauge,
 };
 
 static DISCONTIGUOUS_PAGES_TOTAL: Metric = Metric {
-    name: "discontiguous_pages_total",
+    name: "lustre_discontiguous_pages_total",
     help: "Total number of logical discontinuities per RPC.",
     r#type: MetricType::Counter,
 };
 
 static DISCONTIGUOUS_BLOCKS_TOTAL: Metric = Metric {
-    name: "discontiguous_blocks_total",
+    name: "lustre_discontiguous_blocks_total",
     help: "",
     r#type: MetricType::Counter,
 };
 
 static IO_TIME_MILLISECONDS_TOTAL: Metric = Metric {
-    name: "io_time_milliseconds_total",
+    name: "lustre_io_time_milliseconds_total",
     help: "Total time in milliseconds the filesystem has spent processing various object sizes.",
     r#type: MetricType::Counter,
 };
 
 static PAGES_PER_BULK_RW_TOTAL: Metric = Metric {
-    name: "pages_per_bulk_rw_total",
+    name: "lustre_pages_per_bulk_rw_total",
     help: "Total number of pages per block RPC.",
     r#type: MetricType::Counter,
 };
 
 static INODES_FREE: Metric = Metric {
-    name: "inodes_free",
+    name: "lustre_inodes_free",
     help: "The number of inodes (objects) available",
     r#type: MetricType::Gauge,
 };
 
 static INODES_MAXIMUM: Metric = Metric {
-    name: "inodes_maximum",
+    name: "lustre_inodes_maximum",
     help: "The maximum number of inodes (objects) the filesystem can hold",
     r#type: MetricType::Gauge,
 };
 
 static AVAILABLE_BYTES: Metric = Metric {
-    name: "available_bytes",
+    name: "lustre_available_bytes",
     help: "Number of bytes readily available in the pool",
     r#type: MetricType::Gauge,
 };
 
 static FREE_BYTES: Metric = Metric {
-    name: "free_bytes",
+    name: "lustre_free_bytes",
     help: "Number of bytes allocated to the pool",
     r#type: MetricType::Gauge,
 };
 
 static CAPACITY_BYTES: Metric = Metric {
-    name: "capacity_bytes",
+    name: "lustre_capacity_bytes",
     help: "Capacity of the pool in bytes",
     r#type: MetricType::Gauge,
 };
 
 static EXPORTS_TOTAL: Metric = Metric {
-    name: "exports_total",
+    name: "lustre_exports_total",
     help: "Total number of times the pool has been exported",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_DIRTY_TOTAL: Metric = Metric {
-    name: "exports_dirty_total",
+    name: "lustre_exports_dirty_total",
     help: "Total number of exports that have been marked dirty",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_GRANTED_TOTAL: Metric = Metric {
-    name: "exports_granted_total",
+    name: "lustre_exports_granted_total",
     help: "Total number of exports that have been marked granted",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_PENDING_TOTAL: Metric = Metric {
-    name: "exports_pending_total",
+    name: "lustre_exports_pending_total",
     help: "Total number of exports that have been marked pending",
     r#type: MetricType::Counter,
 };
 
 static LOCK_CONTENDED_TOTAL: Metric = Metric {
-    name: "lock_contended_total",
+    name: "lustre_lock_contended_total",
     help: "Number of contended locks",
     r#type: MetricType::Counter,
 };
 
 static LOCK_CONTENTION_SECONDS_TOTAL: Metric = Metric {
-    name: "lock_contention_seconds_total",
+    name: "lustre_lock_contention_seconds_total",
     help: "Time in seconds during which locks were contended",
     r#type: MetricType::Counter,
 };
 
 static CONNECTED_CLIENTS: Metric = Metric {
-    name: "connected_clients",
+    name: "lustre_connected_clients",
     help: "Number of connected clients",
     r#type: MetricType::Gauge,
 };
 
 static LOCK_COUNT_TOTAL: Metric = Metric {
-    name: "lock_count_total",
+    name: "lustre_lock_count_total",
     help: "Number of locks",
     r#type: MetricType::Counter,
 };
 
 static LOCK_TIMEOUT_TOTAL: Metric = Metric {
-    name: "lock_timeout_total",
+    name: "lustre_lock_timeout_total",
     help: "Number of lock timeouts",
     r#type: MetricType::Counter,
 };

--- a/src/jobstats.rs
+++ b/src/jobstats.rs
@@ -6,43 +6,43 @@ use prometheus_exporter_base::{prelude::*, Yes};
 use crate::{Metric, StatsMapExt};
 
 static READ_SAMPLES: Metric = Metric {
-    name: "job_read_samples_total",
+    name: "lustre_job_read_samples_total",
     help: "Total number of reads that have been recorded.",
     r#type: MetricType::Counter,
 };
 static READ_MIN_SIZE_BYTES: Metric = Metric {
-    name: "job_read_minimum_size_bytes",
+    name: "lustre_job_read_minimum_size_bytes",
     help: "The minimum read size in bytes.",
     r#type: MetricType::Gauge,
 };
 static READ_MAX_SIZE_BYTES: Metric = Metric {
-    name: "job_read_maximum_size_bytes",
+    name: "lustre_job_read_maximum_size_bytes",
     help: "The maximum read size in bytes.",
     r#type: MetricType::Gauge,
 };
 static READ_BYTES: Metric = Metric {
-    name: "job_read_bytes_total",
+    name: "lustre_job_read_bytes_total",
     help: "The total number of bytes that have been read.",
     r#type: MetricType::Counter,
 };
 
 static WRITE_SAMPLES: Metric = Metric {
-    name: "job_write_samples_total",
+    name: "lustre_job_write_samples_total",
     help: "Total number of writes that have been recorded.",
     r#type: MetricType::Counter,
 };
 static WRITE_MIN_SIZE_BYTES: Metric = Metric {
-    name: "job_write_minimum_size_bytes",
+    name: "lustre_job_write_minimum_size_bytes",
     help: "The minimum write size in bytes.",
     r#type: MetricType::Gauge,
 };
 static WRITE_MAX_SIZE_BYTES: Metric = Metric {
-    name: "job_write_maximum_size_bytes",
+    name: "lustre_job_write_maximum_size_bytes",
     help: "The maximum write size in bytes.",
     r#type: MetricType::Gauge,
 };
 static WRITE_BYTES: Metric = Metric {
-    name: "job_write_bytes_total",
+    name: "lustre_job_write_bytes_total",
     help: "The total number of bytes that have been written.",
     r#type: MetricType::Counter,
 };

--- a/src/lnet.rs
+++ b/src/lnet.rs
@@ -6,17 +6,17 @@ use prometheus_exporter_base::prelude::*;
 use crate::{Metric, StatsMapExt, ToMetricInst};
 
 static SEND_COUNT: Metric = Metric {
-    name: "send_count_total",
+    name: "lustre_send_count_total",
     help: "Total number of messages that have been sent",
     r#type: MetricType::Counter,
 };
 static RECEIVE_COUNT: Metric = Metric {
-    name: "receive_count_total",
+    name: "lustre_receive_count_total",
     help: "Total number of messages that have been received",
     r#type: MetricType::Counter,
 };
 static DROP_COUNT: Metric = Metric {
-    name: "drop_count_total",
+    name: "lustre_drop_count_total",
     help: "Total number of messages that have been dropped",
     r#type: MetricType::Counter,
 };

--- a/src/snapshots/lustrefs_exporter__tests__jobstats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__jobstats.snap
@@ -1,308 +1,307 @@
 ---
 source: src/main.rs
-assertion_line: 700
 expression: x
 ---
-# HELP available_bytes Number of bytes readily available in the pool
-# TYPE available_bytes gauge
-available_bytes{component="MGT",target="MGS"} 474824704 0
-available_bytes{component="MDT",target="fs-MDT0000"} 2423201792 0
-available_bytes{component="OST",target="fs-OST0000"} 4135227392 0
-available_bytes{component="OST",target="fs-OST0001"} 4135227392 0
+# HELP lustre_available_bytes Number of bytes readily available in the pool
+# TYPE lustre_available_bytes gauge
+lustre_available_bytes{component="MGT",target="MGS"} 474824704 0
+lustre_available_bytes{component="MDT",target="fs-MDT0000"} 2423201792 0
+lustre_available_bytes{component="OST",target="fs-OST0000"} 4135227392 0
+lustre_available_bytes{component="OST",target="fs-OST0001"} 4135227392 0
 
-# HELP capacity_bytes Capacity of the pool in bytes
-# TYPE capacity_bytes gauge
-capacity_bytes{component="MGT",target="MGS"} 502878208 0
-capacity_bytes{component="MDT",target="fs-MDT0000"} 2665299968 0
-capacity_bytes{component="OST",target="fs-OST0000"} 4206989312 0
-capacity_bytes{component="OST",target="fs-OST0001"} 4206989312 0
+# HELP lustre_capacity_bytes Capacity of the pool in bytes
+# TYPE lustre_capacity_bytes gauge
+lustre_capacity_bytes{component="MGT",target="MGS"} 502878208 0
+lustre_capacity_bytes{component="MDT",target="fs-MDT0000"} 2665299968 0
+lustre_capacity_bytes{component="OST",target="fs-OST0000"} 4206989312 0
+lustre_capacity_bytes{component="OST",target="fs-OST0001"} 4206989312 0
 
-# HELP connected_clients Number of connected clients
-# TYPE connected_clients gauge
-connected_clients{component="MDT",target="fs-MDT0000"} 1 0
-connected_clients{component="MDT",target="fs-MDT0000"} 1 0
+# HELP lustre_connected_clients Number of connected clients
+# TYPE lustre_connected_clients gauge
+lustre_connected_clients{component="MDT",target="fs-MDT0000"} 1 0
+lustre_connected_clients{component="MDT",target="fs-MDT0000"} 1 0
 
-# HELP dio_frags Current disk IO fragmentation for the given size.
-# TYPE dio_frags gauge
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="2"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="2"} 4 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="3"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="3"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="4"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="4"} 1 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="5"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="5"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="6"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="6"} 2 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="7"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="7"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0000",size="8"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0000",size="8"} 11 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="2"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="2"} 5 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="3"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="3"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="4"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="4"} 1 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="5"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="5"} 1 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="6"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="6"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="7"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="7"} 0 0
-dio_frags{component="OST",operation="read",target="fs-OST0001",size="8"} 0 0
-dio_frags{component="OST",operation="write",target="fs-OST0001",size="8"} 12 0
+# HELP lustre_dio_frags Current disk IO fragmentation for the given size.
+# TYPE lustre_dio_frags gauge
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="2"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="2"} 4 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="4"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="4"} 1 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="5"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="5"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="6"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="6"} 2 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="7"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="7"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0000",size="8"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0000",size="8"} 11 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="2"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="2"} 5 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="4"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="4"} 1 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="5"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="5"} 1 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="6"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="6"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="7"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="7"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="fs-OST0001",size="8"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="fs-OST0001",size="8"} 12 0
 
-# HELP discontiguous_blocks_total 
-# TYPE discontiguous_blocks_total counter
-discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0000",size="0"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0000",size="0"} 17 0
-discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0000",size="1"} 1 0
-discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0001",size="0"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0001",size="0"} 19 0
-discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
+# HELP lustre_discontiguous_blocks_total 
+# TYPE lustre_discontiguous_blocks_total counter
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0000",size="0"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0000",size="0"} 17 0
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0000",size="1"} 1 0
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0001",size="0"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0001",size="0"} 19 0
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
 
-# HELP discontiguous_pages_total Total number of logical discontinuities per RPC.
-# TYPE discontiguous_pages_total counter
-discontiguous_pages_total{component="OST",operation="read",target="fs-OST0000",size="0"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="fs-OST0000",size="0"} 17 0
-discontiguous_pages_total{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="fs-OST0000",size="1"} 1 0
-discontiguous_pages_total{component="OST",operation="read",target="fs-OST0001",size="0"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="fs-OST0001",size="0"} 19 0
-discontiguous_pages_total{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
+# HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
+# TYPE lustre_discontiguous_pages_total counter
+lustre_discontiguous_pages_total{component="OST",operation="read",target="fs-OST0000",size="0"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="fs-OST0000",size="0"} 17 0
+lustre_discontiguous_pages_total{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="fs-OST0000",size="1"} 1 0
+lustre_discontiguous_pages_total{component="OST",operation="read",target="fs-OST0001",size="0"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="fs-OST0001",size="0"} 19 0
+lustre_discontiguous_pages_total{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="fs-OST0001",size="1"} 1 0
 
-# HELP disk_io Current number of I/O operations that are processing during the snapshot.
-# TYPE disk_io gauge
-disk_io{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="1"} 13 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="2"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="2"} 18 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="3"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="3"} 29 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="4"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="4"} 19 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="5"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="5"} 14 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="6"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="6"} 11 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="7"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="7"} 6 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="8"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="8"} 1 0
-disk_io{component="OST",operation="read",target="fs-OST0000",size="9"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0000",size="9"} 1 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="1"} 15 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="2"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="2"} 17 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="3"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="3"} 23 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="4"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="4"} 16 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="5"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="5"} 15 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="6"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="6"} 13 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="7"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="7"} 6 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="8"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="8"} 2 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="9"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="9"} 2 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="10"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="10"} 1 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="11"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="11"} 4 0
-disk_io{component="OST",operation="read",target="fs-OST0001",size="12"} 0 0
-disk_io{component="OST",operation="write",target="fs-OST0001",size="12"} 2 0
+# HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
+# TYPE lustre_disk_io gauge
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="1"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="1"} 13 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="2"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="2"} 18 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="3"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="3"} 29 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="4"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="4"} 19 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="5"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="5"} 14 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="6"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="6"} 11 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="7"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="7"} 6 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="8"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="8"} 1 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0000",size="9"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0000",size="9"} 1 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="1"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="1"} 15 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="2"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="2"} 17 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="3"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="3"} 23 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="4"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="4"} 16 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="5"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="5"} 15 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="6"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="6"} 13 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="7"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="7"} 6 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="8"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="8"} 2 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="9"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="9"} 2 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="10"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="10"} 1 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="11"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="11"} 4 0
+lustre_disk_io{component="OST",operation="read",target="fs-OST0001",size="12"} 0 0
+lustre_disk_io{component="OST",operation="write",target="fs-OST0001",size="12"} 2 0
 
-# HELP disk_io_total Total number of operations the filesystem has performed for the given size.
-# TYPE disk_io_total counter
-disk_io_total{component="OST",operation="read",target="fs-OST0000",size="524288"} 0 0
-disk_io_total{component="OST",operation="write",target="fs-OST0000",size="524288"} 112 0
-disk_io_total{component="OST",operation="read",target="fs-OST0001",size="524288"} 0 0
-disk_io_total{component="OST",operation="write",target="fs-OST0001",size="524288"} 116 0
+# HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
+# TYPE lustre_disk_io_total counter
+lustre_disk_io_total{component="OST",operation="read",target="fs-OST0000",size="524288"} 0 0
+lustre_disk_io_total{component="OST",operation="write",target="fs-OST0000",size="524288"} 112 0
+lustre_disk_io_total{component="OST",operation="read",target="fs-OST0001",size="524288"} 0 0
+lustre_disk_io_total{component="OST",operation="write",target="fs-OST0001",size="524288"} 116 0
 
-# HELP drop_count_total Total number of messages that have been dropped
-# TYPE drop_count_total counter
-drop_count_total{nid="0@lo"} 3 0
-drop_count_total{nid="10.73.20.11@tcp"} 5 0
-drop_count_total{nid="10.73.20.51@tcp"} 6 0
+# HELP lustre_drop_count_total Total number of messages that have been dropped
+# TYPE lustre_drop_count_total counter
+lustre_drop_count_total{nid="0@lo"} 3 0
+lustre_drop_count_total{nid="10.73.20.11@tcp"} 5 0
+lustre_drop_count_total{nid="10.73.20.51@tcp"} 6 0
 
-# HELP exports_dirty_total Total number of exports that have been marked dirty
-# TYPE exports_dirty_total counter
-exports_dirty_total{component="OST",target="fs-OST0000"} 0 0
-exports_dirty_total{component="OST",target="fs-OST0001"} 0 0
+# HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
+# TYPE lustre_exports_dirty_total counter
+lustre_exports_dirty_total{component="OST",target="fs-OST0000"} 0 0
+lustre_exports_dirty_total{component="OST",target="fs-OST0001"} 0 0
 
-# HELP exports_granted_total Total number of exports that have been marked granted
-# TYPE exports_granted_total counter
-exports_granted_total{component="OST",target="fs-OST0000"} 98188992 0
-exports_granted_total{component="OST",target="fs-OST0001"} 113017408 0
+# HELP lustre_exports_granted_total Total number of exports that have been marked granted
+# TYPE lustre_exports_granted_total counter
+lustre_exports_granted_total{component="OST",target="fs-OST0000"} 98188992 0
+lustre_exports_granted_total{component="OST",target="fs-OST0001"} 113017408 0
 
-# HELP exports_pending_total Total number of exports that have been marked pending
-# TYPE exports_pending_total counter
-exports_pending_total{component="OST",target="fs-OST0000"} 0 0
-exports_pending_total{component="OST",target="fs-OST0001"} 0 0
+# HELP lustre_exports_pending_total Total number of exports that have been marked pending
+# TYPE lustre_exports_pending_total counter
+lustre_exports_pending_total{component="OST",target="fs-OST0000"} 0 0
+lustre_exports_pending_total{component="OST",target="fs-OST0001"} 0 0
 
-# HELP exports_total Total number of times the pool has been exported
-# TYPE exports_total counter
-exports_total{component="MGT",target="MGS"} 4 0
-exports_total{component="OST",target="fs-OST0000"} 2 0
-exports_total{component="OST",target="fs-OST0001"} 2 0
-exports_total{component="MDT",target="fs-MDT0000"} 10 0
+# HELP lustre_exports_total Total number of times the pool has been exported
+# TYPE lustre_exports_total counter
+lustre_exports_total{component="MGT",target="MGS"} 4 0
+lustre_exports_total{component="OST",target="fs-OST0000"} 2 0
+lustre_exports_total{component="OST",target="fs-OST0001"} 2 0
+lustre_exports_total{component="MDT",target="fs-MDT0000"} 10 0
 
-# HELP free_bytes Number of bytes allocated to the pool
-# TYPE free_bytes gauge
-free_bytes{component="MGT",target="MGS"} 501665792 0
-free_bytes{component="MDT",target="fs-MDT0000"} 2662928384 0
-free_bytes{component="OST",target="fs-OST0000"} 4205690880 0
-free_bytes{component="OST",target="fs-OST0001"} 4205690880 0
+# HELP lustre_free_bytes Number of bytes allocated to the pool
+# TYPE lustre_free_bytes gauge
+lustre_free_bytes{component="MGT",target="MGS"} 501665792 0
+lustre_free_bytes{component="MDT",target="fs-MDT0000"} 2662928384 0
+lustre_free_bytes{component="OST",target="fs-OST0000"} 4205690880 0
+lustre_free_bytes{component="OST",target="fs-OST0001"} 4205690880 0
 
-# HELP inodes_free The number of inodes (objects) available
-# TYPE inodes_free gauge
-inodes_free{component="MGT",target="MGS"} 32570 0
-inodes_free{component="MDT",target="fs-MDT0000"} 1885348 0
-inodes_free{component="OST",target="fs-OST0000"} 40628 0
-inodes_free{component="OST",target="fs-OST0001"} 40628 0
+# HELP lustre_inodes_free The number of inodes (objects) available
+# TYPE lustre_inodes_free gauge
+lustre_inodes_free{component="MGT",target="MGS"} 32570 0
+lustre_inodes_free{component="MDT",target="fs-MDT0000"} 1885348 0
+lustre_inodes_free{component="OST",target="fs-OST0000"} 40628 0
+lustre_inodes_free{component="OST",target="fs-OST0001"} 40628 0
 
-# HELP inodes_maximum The maximum number of inodes (objects) the filesystem can hold
-# TYPE inodes_maximum gauge
-inodes_maximum{component="MGT",target="MGS"} 32768 0
-inodes_maximum{component="MDT",target="fs-MDT0000"} 1885696 0
-inodes_maximum{component="OST",target="fs-OST0000"} 40960 0
-inodes_maximum{component="OST",target="fs-OST0001"} 40960 0
+# HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
+# TYPE lustre_inodes_maximum gauge
+lustre_inodes_maximum{component="MGT",target="MGS"} 32768 0
+lustre_inodes_maximum{component="MDT",target="fs-MDT0000"} 1885696 0
+lustre_inodes_maximum{component="OST",target="fs-OST0000"} 40960 0
+lustre_inodes_maximum{component="OST",target="fs-OST0001"} 40960 0
 
-# HELP io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
-# TYPE io_time_milliseconds_total counter
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="16"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="16"} 2 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="32"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="32"} 4 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="64"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="64"} 9 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="128"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="128"} 3 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="16"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="16"} 1 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="32"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="32"} 10 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="64"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="64"} 5 0
-io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="128"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="128"} 4 0
+# HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
+# TYPE lustre_io_time_milliseconds_total counter
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="16"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="16"} 2 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="32"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="32"} 4 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="64"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="64"} 9 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0000",size="128"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0000",size="128"} 3 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="16"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="16"} 1 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="32"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="32"} 10 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="64"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="64"} 5 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="fs-OST0001",size="128"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="fs-OST0001",size="128"} 4 0
 
-# HELP job_read_bytes_total The total number of bytes that have been read.
-# TYPE job_read_bytes_total counter
-job_read_bytes_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_read_bytes_total{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
-job_read_bytes_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_read_bytes_total{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
+# HELP lustre_job_read_bytes_total The total number of bytes that have been read.
+# TYPE lustre_job_read_bytes_total counter
+lustre_job_read_bytes_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_bytes_total{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
+lustre_job_read_bytes_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_bytes_total{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
 
-# HELP job_read_maximum_size_bytes The maximum read size in bytes.
-# TYPE job_read_maximum_size_bytes gauge
-job_read_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_read_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
-job_read_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_read_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
+# HELP lustre_job_read_maximum_size_bytes The maximum read size in bytes.
+# TYPE lustre_job_read_maximum_size_bytes gauge
+lustre_job_read_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
+lustre_job_read_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
 
-# HELP job_read_minimum_size_bytes The minimum read size in bytes.
-# TYPE job_read_minimum_size_bytes gauge
-job_read_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_read_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
-job_read_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_read_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
+# HELP lustre_job_read_minimum_size_bytes The minimum read size in bytes.
+# TYPE lustre_job_read_minimum_size_bytes gauge
+lustre_job_read_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
+lustre_job_read_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
 
-# HELP job_read_samples_total Total number of reads that have been recorded.
-# TYPE job_read_samples_total counter
-job_read_samples_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_read_samples_total{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
-job_read_samples_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_read_samples_total{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
+# HELP lustre_job_read_samples_total Total number of reads that have been recorded.
+# TYPE lustre_job_read_samples_total counter
+lustre_job_read_samples_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_samples_total{component="OST",target="fs-OST0000",jobid="dd.0"} 0 0
+lustre_job_read_samples_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_read_samples_total{component="OST",target="fs-OST0001",jobid="dd.0"} 0 0
 
-# HELP job_write_bytes_total The total number of bytes that have been written.
-# TYPE job_write_bytes_total counter
-job_write_bytes_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_write_bytes_total{component="OST",target="fs-OST0000",jobid="dd.0"} 57671680 0
-job_write_bytes_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_write_bytes_total{component="OST",target="fs-OST0001",jobid="dd.0"} 59670528 0
+# HELP lustre_job_write_bytes_total The total number of bytes that have been written.
+# TYPE lustre_job_write_bytes_total counter
+lustre_job_write_bytes_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_bytes_total{component="OST",target="fs-OST0000",jobid="dd.0"} 57671680 0
+lustre_job_write_bytes_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_bytes_total{component="OST",target="fs-OST0001",jobid="dd.0"} 59670528 0
 
-# HELP job_write_maximum_size_bytes The maximum write size in bytes.
-# TYPE job_write_maximum_size_bytes gauge
-job_write_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_write_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 4194304 0
-job_write_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_write_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 4194304 0
+# HELP lustre_job_write_maximum_size_bytes The maximum write size in bytes.
+# TYPE lustre_job_write_maximum_size_bytes gauge
+lustre_job_write_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_maximum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 4194304 0
+lustre_job_write_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_maximum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 4194304 0
 
-# HELP job_write_minimum_size_bytes The minimum write size in bytes.
-# TYPE job_write_minimum_size_bytes gauge
-job_write_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_write_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 1048576 0
-job_write_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_write_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 524288 0
+# HELP lustre_job_write_minimum_size_bytes The minimum write size in bytes.
+# TYPE lustre_job_write_minimum_size_bytes gauge
+lustre_job_write_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_minimum_size_bytes{component="OST",target="fs-OST0000",jobid="dd.0"} 1048576 0
+lustre_job_write_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_minimum_size_bytes{component="OST",target="fs-OST0001",jobid="dd.0"} 524288 0
 
-# HELP job_write_samples_total Total number of writes that have been recorded.
-# TYPE job_write_samples_total counter
-job_write_samples_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-job_write_samples_total{component="OST",target="fs-OST0000",jobid="dd.0"} 17 0
-job_write_samples_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-job_write_samples_total{component="OST",target="fs-OST0001",jobid="dd.0"} 19 0
+# HELP lustre_job_write_samples_total Total number of writes that have been recorded.
+# TYPE lustre_job_write_samples_total counter
+lustre_job_write_samples_total{component="OST",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_samples_total{component="OST",target="fs-OST0000",jobid="dd.0"} 17 0
+lustre_job_write_samples_total{component="OST",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
+lustre_job_write_samples_total{component="OST",target="fs-OST0001",jobid="dd.0"} 19 0
 
-# HELP lock_contended_total Number of contended locks
-# TYPE lock_contended_total counter
-lock_contended_total{component="MDT",target="fs-MDT0000"} 32 0
-lock_contended_total{component="OST",target="fs-OST0000"} 32 0
-lock_contended_total{component="OST",target="fs-OST0001"} 32 0
+# HELP lustre_lock_contended_total Number of contended locks
+# TYPE lustre_lock_contended_total counter
+lustre_lock_contended_total{component="MDT",target="fs-MDT0000"} 32 0
+lustre_lock_contended_total{component="OST",target="fs-OST0000"} 32 0
+lustre_lock_contended_total{component="OST",target="fs-OST0001"} 32 0
 
-# HELP lock_contention_seconds_total Time in seconds during which locks were contended
-# TYPE lock_contention_seconds_total counter
-lock_contention_seconds_total{component="MDT",target="fs-MDT0000"} 2 0
-lock_contention_seconds_total{component="OST",target="fs-OST0000"} 2 0
-lock_contention_seconds_total{component="OST",target="fs-OST0001"} 2 0
+# HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended
+# TYPE lustre_lock_contention_seconds_total counter
+lustre_lock_contention_seconds_total{component="MDT",target="fs-MDT0000"} 2 0
+lustre_lock_contention_seconds_total{component="OST",target="fs-OST0000"} 2 0
+lustre_lock_contention_seconds_total{component="OST",target="fs-OST0001"} 2 0
 
-# HELP lock_count_total Number of locks
-# TYPE lock_count_total counter
-lock_count_total{component="MDT",target="fs-MDT0000"} 32 0
-lock_count_total{component="OST",target="fs-OST0000"} 1 0
-lock_count_total{component="OST",target="fs-OST0001"} 1 0
+# HELP lustre_lock_count_total Number of locks
+# TYPE lustre_lock_count_total counter
+lustre_lock_count_total{component="MDT",target="fs-MDT0000"} 32 0
+lustre_lock_count_total{component="OST",target="fs-OST0000"} 1 0
+lustre_lock_count_total{component="OST",target="fs-OST0001"} 1 0
 
-# HELP lock_timeout_total Number of lock timeouts
-# TYPE lock_timeout_total counter
-lock_timeout_total{component="MDT",target="fs-MDT0000"} 0 0
-lock_timeout_total{component="OST",target="fs-OST0000"} 0 0
-lock_timeout_total{component="OST",target="fs-OST0001"} 0 0
+# HELP lustre_lock_timeout_total Number of lock timeouts
+# TYPE lustre_lock_timeout_total counter
+lustre_lock_timeout_total{component="MDT",target="fs-MDT0000"} 0 0
+lustre_lock_timeout_total{component="OST",target="fs-OST0000"} 0 0
+lustre_lock_timeout_total{component="OST",target="fs-OST0001"} 0 0
 
-# HELP pages_per_bulk_rw_total Total number of pages per block RPC.
-# TYPE pages_per_bulk_rw_total counter
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="256"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="256"} 4 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="512"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="512"} 1 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="1024"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="1024"} 13 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="128"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="128"} 1 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="256"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="256"} 5 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="512"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="512"} 1 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="1024"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="1024"} 13 0
+# HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
+# TYPE lustre_pages_per_bulk_rw_total counter
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="256"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="256"} 4 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="512"} 1 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0000",size="1024"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0000",size="1024"} 13 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="128"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="128"} 1 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="256"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="256"} 5 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="512"} 1 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="fs-OST0001",size="1024"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="fs-OST0001",size="1024"} 13 0
 
-# HELP receive_count_total Total number of messages that have been received
-# TYPE receive_count_total counter
-receive_count_total{nid="0@lo"} 27011 0
-receive_count_total{nid="10.73.20.11@tcp"} 25960 0
-receive_count_total{nid="10.73.20.51@tcp"} 25880 0
+# HELP lustre_receive_count_total Total number of messages that have been received
+# TYPE lustre_receive_count_total counter
+lustre_receive_count_total{nid="0@lo"} 27011 0
+lustre_receive_count_total{nid="10.73.20.11@tcp"} 25960 0
+lustre_receive_count_total{nid="10.73.20.51@tcp"} 25880 0
 
-# HELP send_count_total Total number of messages that have been sent
-# TYPE send_count_total counter
-send_count_total{nid="0@lo"} 27014 0
-send_count_total{nid="10.73.20.11@tcp"} 25956 0
-send_count_total{nid="10.73.20.51@tcp"} 25870 0
+# HELP lustre_send_count_total Total number of messages that have been sent
+# TYPE lustre_send_count_total counter
+lustre_send_count_total{nid="0@lo"} 27014 0
+lustre_send_count_total{nid="10.73.20.11@tcp"} 25956 0
+lustre_send_count_total{nid="10.73.20.51@tcp"} 25870 0
 

--- a/src/snapshots/lustrefs_exporter__tests__stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__stats.snap
@@ -1,194 +1,193 @@
 ---
 source: src/main.rs
-assertion_line: 537
 expression: x
 ---
-# HELP available_bytes Number of bytes readily available in the pool
-# TYPE available_bytes gauge
-available_bytes{component="MGT",target="MGS"} 1918767104 0
-available_bytes{component="MDT",target="ai400x2-MDT0000"} 142034284544 0
-available_bytes{component="OST",target="ai400x2-OST0000"} 3334853013504 0
-available_bytes{component="OST",target="ai400x2-OST0001"} 3335272443904 0
+# HELP lustre_available_bytes Number of bytes readily available in the pool
+# TYPE lustre_available_bytes gauge
+lustre_available_bytes{component="MGT",target="MGS"} 1918767104 0
+lustre_available_bytes{component="MDT",target="ai400x2-MDT0000"} 142034284544 0
+lustre_available_bytes{component="OST",target="ai400x2-OST0000"} 3334853013504 0
+lustre_available_bytes{component="OST",target="ai400x2-OST0001"} 3335272443904 0
 
-# HELP capacity_bytes Capacity of the pool in bytes
-# TYPE capacity_bytes gauge
-capacity_bytes{component="MGT",target="MGS"} 2027556864 0
-capacity_bytes{component="MDT",target="ai400x2-MDT0000"} 144541634560 0
-capacity_bytes{component="OST",target="ai400x2-OST0000"} 3544070828032 0
-capacity_bytes{component="OST",target="ai400x2-OST0001"} 3544070828032 0
+# HELP lustre_capacity_bytes Capacity of the pool in bytes
+# TYPE lustre_capacity_bytes gauge
+lustre_capacity_bytes{component="MGT",target="MGS"} 2027556864 0
+lustre_capacity_bytes{component="MDT",target="ai400x2-MDT0000"} 144541634560 0
+lustre_capacity_bytes{component="OST",target="ai400x2-OST0000"} 3544070828032 0
+lustre_capacity_bytes{component="OST",target="ai400x2-OST0001"} 3544070828032 0
 
-# HELP connected_clients Number of connected clients
-# TYPE connected_clients gauge
-connected_clients{component="MDT",target="ai400x2-MDT0000"} 4 0
-connected_clients{component="MDT",target="ai400x2-MDT0000"} 4 0
+# HELP lustre_connected_clients Number of connected clients
+# TYPE lustre_connected_clients gauge
+lustre_connected_clients{component="MDT",target="ai400x2-MDT0000"} 4 0
+lustre_connected_clients{component="MDT",target="ai400x2-MDT0000"} 4 0
 
-# HELP dio_frags Current disk IO fragmentation for the given size.
-# TYPE dio_frags gauge
-dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 2 0
-dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 0 0
-dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="3"} 0 0
-dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="3"} 0 0
-dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 736 0
-dio_frags{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-dio_frags{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 625 0
+# HELP lustre_dio_frags Current disk IO fragmentation for the given size.
+# TYPE lustre_dio_frags gauge
+lustre_dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 2 0
+lustre_dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="3"} 0 0
+lustre_dio_frags{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 736 0
+lustre_dio_frags{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
+lustre_dio_frags{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 625 0
 
-# HELP discontiguous_blocks_total 
-# TYPE discontiguous_blocks_total counter
-discontiguous_blocks_total{component="OST",operation="read",target="ai400x2-OST0000",size="0"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="ai400x2-OST0000",size="0"} 738 0
-discontiguous_blocks_total{component="OST",operation="read",target="ai400x2-OST0001",size="0"} 0 0
-discontiguous_blocks_total{component="OST",operation="write",target="ai400x2-OST0001",size="0"} 625 0
+# HELP lustre_discontiguous_blocks_total 
+# TYPE lustre_discontiguous_blocks_total counter
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="ai400x2-OST0000",size="0"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="ai400x2-OST0000",size="0"} 738 0
+lustre_discontiguous_blocks_total{component="OST",operation="read",target="ai400x2-OST0001",size="0"} 0 0
+lustre_discontiguous_blocks_total{component="OST",operation="write",target="ai400x2-OST0001",size="0"} 625 0
 
-# HELP discontiguous_pages_total Total number of logical discontinuities per RPC.
-# TYPE discontiguous_pages_total counter
-discontiguous_pages_total{component="OST",operation="read",target="ai400x2-OST0000",size="0"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="ai400x2-OST0000",size="0"} 738 0
-discontiguous_pages_total{component="OST",operation="read",target="ai400x2-OST0001",size="0"} 0 0
-discontiguous_pages_total{component="OST",operation="write",target="ai400x2-OST0001",size="0"} 625 0
+# HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
+# TYPE lustre_discontiguous_pages_total counter
+lustre_discontiguous_pages_total{component="OST",operation="read",target="ai400x2-OST0000",size="0"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="ai400x2-OST0000",size="0"} 738 0
+lustre_discontiguous_pages_total{component="OST",operation="read",target="ai400x2-OST0001",size="0"} 0 0
+lustre_discontiguous_pages_total{component="OST",operation="write",target="ai400x2-OST0001",size="0"} 625 0
 
-# HELP disk_io Current number of I/O operations that are processing during the snapshot.
-# TYPE disk_io gauge
-disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 738 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 736 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="3"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="3"} 736 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 736 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="1"} 625 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="2"} 625 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="3"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="3"} 625 0
-disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 625 0
+# HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
+# TYPE lustre_disk_io gauge
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 738 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 736 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="3"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="3"} 736 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 736 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="1"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="1"} 625 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="2"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="2"} 625 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="3"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="3"} 625 0
+lustre_disk_io{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
+lustre_disk_io{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 625 0
 
-# HELP disk_io_total Total number of operations the filesystem has performed for the given size.
-# TYPE disk_io_total counter
-disk_io_total{component="OST",operation="read",target="ai400x2-OST0000",size="1048576"} 0 0
-disk_io_total{component="OST",operation="write",target="ai400x2-OST0000",size="1048576"} 2946 0
-disk_io_total{component="OST",operation="read",target="ai400x2-OST0001",size="1048576"} 0 0
-disk_io_total{component="OST",operation="write",target="ai400x2-OST0001",size="1048576"} 2500 0
+# HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
+# TYPE lustre_disk_io_total counter
+lustre_disk_io_total{component="OST",operation="read",target="ai400x2-OST0000",size="1048576"} 0 0
+lustre_disk_io_total{component="OST",operation="write",target="ai400x2-OST0000",size="1048576"} 2946 0
+lustre_disk_io_total{component="OST",operation="read",target="ai400x2-OST0001",size="1048576"} 0 0
+lustre_disk_io_total{component="OST",operation="write",target="ai400x2-OST0001",size="1048576"} 2500 0
 
-# HELP drop_count_total Total number of messages that have been dropped
-# TYPE drop_count_total counter
-drop_count_total{nid="0@lo"} 125 0
-drop_count_total{nid="172.16.0.24@o2ib"} 57 0
-drop_count_total{nid="172.16.0.28@o2ib"} 69 0
+# HELP lustre_drop_count_total Total number of messages that have been dropped
+# TYPE lustre_drop_count_total counter
+lustre_drop_count_total{nid="0@lo"} 125 0
+lustre_drop_count_total{nid="172.16.0.24@o2ib"} 57 0
+lustre_drop_count_total{nid="172.16.0.28@o2ib"} 69 0
 
-# HELP exports_dirty_total Total number of exports that have been marked dirty
-# TYPE exports_dirty_total counter
-exports_dirty_total{component="OST",target="ai400x2-OST0000"} 0 0
-exports_dirty_total{component="OST",target="ai400x2-OST0001"} 0 0
+# HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
+# TYPE lustre_exports_dirty_total counter
+lustre_exports_dirty_total{component="OST",target="ai400x2-OST0000"} 0 0
+lustre_exports_dirty_total{component="OST",target="ai400x2-OST0001"} 0 0
 
-# HELP exports_granted_total Total number of exports that have been marked granted
-# TYPE exports_granted_total counter
-exports_granted_total{component="OST",target="ai400x2-OST0000"} 276416 0
-exports_granted_total{component="OST",target="ai400x2-OST0001"} 276416 0
+# HELP lustre_exports_granted_total Total number of exports that have been marked granted
+# TYPE lustre_exports_granted_total counter
+lustre_exports_granted_total{component="OST",target="ai400x2-OST0000"} 276416 0
+lustre_exports_granted_total{component="OST",target="ai400x2-OST0001"} 276416 0
 
-# HELP exports_pending_total Total number of exports that have been marked pending
-# TYPE exports_pending_total counter
-exports_pending_total{component="OST",target="ai400x2-OST0000"} 0 0
-exports_pending_total{component="OST",target="ai400x2-OST0001"} 0 0
+# HELP lustre_exports_pending_total Total number of exports that have been marked pending
+# TYPE lustre_exports_pending_total counter
+lustre_exports_pending_total{component="OST",target="ai400x2-OST0000"} 0 0
+lustre_exports_pending_total{component="OST",target="ai400x2-OST0001"} 0 0
 
-# HELP exports_total Total number of times the pool has been exported
-# TYPE exports_total counter
-exports_total{component="MGT",target="MGS"} 4 0
-exports_total{component="OST",target="ai400x2-OST0000"} 4 0
-exports_total{component="OST",target="ai400x2-OST0001"} 4 0
-exports_total{component="MDT",target="ai400x2-MDT0000"} 19 0
+# HELP lustre_exports_total Total number of times the pool has been exported
+# TYPE lustre_exports_total counter
+lustre_exports_total{component="MGT",target="MGS"} 4 0
+lustre_exports_total{component="OST",target="ai400x2-OST0000"} 4 0
+lustre_exports_total{component="OST",target="ai400x2-OST0001"} 4 0
+lustre_exports_total{component="MDT",target="ai400x2-MDT0000"} 19 0
 
-# HELP free_bytes Number of bytes allocated to the pool
-# TYPE free_bytes gauge
-free_bytes{component="MGT",target="MGS"} 2026139648 0
-free_bytes{component="MDT",target="ai400x2-MDT0000"} 144535597056 0
-free_bytes{component="OST",target="ai400x2-OST0000"} 3541028220928 0
-free_bytes{component="OST",target="ai400x2-OST0001"} 3541447651328 0
+# HELP lustre_free_bytes Number of bytes allocated to the pool
+# TYPE lustre_free_bytes gauge
+lustre_free_bytes{component="MGT",target="MGS"} 2026139648 0
+lustre_free_bytes{component="MDT",target="ai400x2-MDT0000"} 144535597056 0
+lustre_free_bytes{component="OST",target="ai400x2-OST0000"} 3541028220928 0
+lustre_free_bytes{component="OST",target="ai400x2-OST0001"} 3541447651328 0
 
-# HELP inodes_free The number of inodes (objects) available
-# TYPE inodes_free gauge
-inodes_free{component="MGT",target="MGS"} 130871 0
-inodes_free{component="MDT",target="ai400x2-MDT0000"} 97713887 0
-inodes_free{component="OST",target="ai400x2-OST0000"} 1073740846 0
-inodes_free{component="OST",target="ai400x2-OST0001"} 1073740847 0
+# HELP lustre_inodes_free The number of inodes (objects) available
+# TYPE lustre_inodes_free gauge
+lustre_inodes_free{component="MGT",target="MGS"} 130871 0
+lustre_inodes_free{component="MDT",target="ai400x2-MDT0000"} 97713887 0
+lustre_inodes_free{component="OST",target="ai400x2-OST0000"} 1073740846 0
+lustre_inodes_free{component="OST",target="ai400x2-OST0001"} 1073740847 0
 
-# HELP inodes_maximum The maximum number of inodes (objects) the filesystem can hold
-# TYPE inodes_maximum gauge
-inodes_maximum{component="MGT",target="MGS"} 131072 0
-inodes_maximum{component="MDT",target="ai400x2-MDT0000"} 97714176 0
-inodes_maximum{component="OST",target="ai400x2-OST0000"} 1073741824 0
-inodes_maximum{component="OST",target="ai400x2-OST0001"} 1073741824 0
+# HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
+# TYPE lustre_inodes_maximum gauge
+lustre_inodes_maximum{component="MGT",target="MGS"} 131072 0
+lustre_inodes_maximum{component="MDT",target="ai400x2-MDT0000"} 97714176 0
+lustre_inodes_maximum{component="OST",target="ai400x2-OST0000"} 1073741824 0
+lustre_inodes_maximum{component="OST",target="ai400x2-OST0001"} 1073741824 0
 
-# HELP io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
-# TYPE io_time_milliseconds_total counter
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 734 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 0 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 3 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="8"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="8"} 1 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="1"} 621 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="2"} 0 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 0 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="8"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="8"} 1 0
-io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="16"} 0 0
-io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="16"} 3 0
+# HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
+# TYPE lustre_io_time_milliseconds_total counter
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="1"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="1"} 734 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="2"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="2"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="4"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="4"} 3 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0000",size="8"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0000",size="8"} 1 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="1"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="1"} 621 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="2"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="2"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="4"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="4"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="8"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="8"} 1 0
+lustre_io_time_milliseconds_total{component="OST",operation="read",target="ai400x2-OST0001",size="16"} 0 0
+lustre_io_time_milliseconds_total{component="OST",operation="write",target="ai400x2-OST0001",size="16"} 3 0
 
-# HELP lock_contended_total Number of contended locks
-# TYPE lock_contended_total counter
-lock_contended_total{component="MDT",target="ai400x2-MDT0000"} 32 0
-lock_contended_total{component="OST",target="ai400x2-OST0000"} 32 0
-lock_contended_total{component="OST",target="ai400x2-OST0001"} 32 0
+# HELP lustre_lock_contended_total Number of contended locks
+# TYPE lustre_lock_contended_total counter
+lustre_lock_contended_total{component="MDT",target="ai400x2-MDT0000"} 32 0
+lustre_lock_contended_total{component="OST",target="ai400x2-OST0000"} 32 0
+lustre_lock_contended_total{component="OST",target="ai400x2-OST0001"} 32 0
 
-# HELP lock_contention_seconds_total Time in seconds during which locks were contended
-# TYPE lock_contention_seconds_total counter
-lock_contention_seconds_total{component="MDT",target="ai400x2-MDT0000"} 2 0
-lock_contention_seconds_total{component="OST",target="ai400x2-OST0000"} 2 0
-lock_contention_seconds_total{component="OST",target="ai400x2-OST0001"} 2 0
+# HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended
+# TYPE lustre_lock_contention_seconds_total counter
+lustre_lock_contention_seconds_total{component="MDT",target="ai400x2-MDT0000"} 2 0
+lustre_lock_contention_seconds_total{component="OST",target="ai400x2-OST0000"} 2 0
+lustre_lock_contention_seconds_total{component="OST",target="ai400x2-OST0001"} 2 0
 
-# HELP lock_count_total Number of locks
-# TYPE lock_count_total counter
-lock_count_total{component="MDT",target="ai400x2-MDT0000"} 0 0
-lock_count_total{component="OST",target="ai400x2-OST0000"} 0 0
-lock_count_total{component="OST",target="ai400x2-OST0001"} 0 0
+# HELP lustre_lock_count_total Number of locks
+# TYPE lustre_lock_count_total counter
+lustre_lock_count_total{component="MDT",target="ai400x2-MDT0000"} 0 0
+lustre_lock_count_total{component="OST",target="ai400x2-OST0000"} 0 0
+lustre_lock_count_total{component="OST",target="ai400x2-OST0001"} 0 0
 
-# HELP lock_timeout_total Number of lock timeouts
-# TYPE lock_timeout_total counter
-lock_timeout_total{component="MDT",target="ai400x2-MDT0000"} 0 0
-lock_timeout_total{component="OST",target="ai400x2-OST0000"} 0 0
-lock_timeout_total{component="OST",target="ai400x2-OST0001"} 0 0
+# HELP lustre_lock_timeout_total Number of lock timeouts
+# TYPE lustre_lock_timeout_total counter
+lustre_lock_timeout_total{component="MDT",target="ai400x2-MDT0000"} 0 0
+lustre_lock_timeout_total{component="OST",target="ai400x2-OST0000"} 0 0
+lustre_lock_timeout_total{component="OST",target="ai400x2-OST0001"} 0 0
 
-# HELP pages_per_bulk_rw_total Total number of pages per block RPC.
-# TYPE pages_per_bulk_rw_total counter
-pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="256"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="256"} 2 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="512"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="512"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="1024"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="1024"} 736 0
-pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0001",size="1024"} 0 0
-pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0001",size="1024"} 625 0
+# HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
+# TYPE lustre_pages_per_bulk_rw_total counter
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="256"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="256"} 2 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0000",size="1024"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0000",size="1024"} 736 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="read",target="ai400x2-OST0001",size="1024"} 0 0
+lustre_pages_per_bulk_rw_total{component="OST",operation="write",target="ai400x2-OST0001",size="1024"} 625 0
 
-# HELP receive_count_total Total number of messages that have been received
-# TYPE receive_count_total counter
-receive_count_total{nid="0@lo"} 3646880 0
-receive_count_total{nid="172.16.0.24@o2ib"} 12463326 0
-receive_count_total{nid="172.16.0.28@o2ib"} 12462034 0
+# HELP lustre_receive_count_total Total number of messages that have been received
+# TYPE lustre_receive_count_total counter
+lustre_receive_count_total{nid="0@lo"} 3646880 0
+lustre_receive_count_total{nid="172.16.0.24@o2ib"} 12463326 0
+lustre_receive_count_total{nid="172.16.0.28@o2ib"} 12462034 0
 
-# HELP send_count_total Total number of messages that have been sent
-# TYPE send_count_total counter
-send_count_total{nid="0@lo"} 3647005 0
-send_count_total{nid="172.16.0.24@o2ib"} 12450030 0
-send_count_total{nid="172.16.0.28@o2ib"} 12448709 0
+# HELP lustre_send_count_total Total number of messages that have been sent
+# TYPE lustre_send_count_total counter
+lustre_send_count_total{nid="0@lo"} 3647005 0
+lustre_send_count_total{nid="172.16.0.24@o2ib"} 12450030 0
+lustre_send_count_total{nid="172.16.0.28@o2ib"} 12448709 0
 


### PR DESCRIPTION
Fixes #3 

If you think of a better way to add a namespace that's concatenated with the metric name, I haven't been able to find one.