### PR TITLE
Add LDLM stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,8 +501,9 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 
 [[package]]
 name = "lustre_collector"
-version = "0.7.1"
-source = "git+https://github.com/whamcloud/lustre-collector#c072527fb6061363e926c8604a6eb0d04a9ff78f"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d14041effdd770419d421860048f000dc849b470a482e416b0dd51c9bf3e225d"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,8 +502,7 @@ checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
 [[package]]
 name = "lustre_collector"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d06b4c22de6e9a045c0a26a2a87da29cd3b7731de83ca0fe206a1bed3d1235c0"
+source = "git+https://github.com/whamcloud/lustre-collector#c072527fb6061363e926c8604a6eb0d04a9ff78f"
 dependencies = [
  "clap",
  "combine",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "lustrefs-exporter"
 version = "0.2.3"
 
 [dependencies]
-lustre_collector = "0.7"
+lustre_collector = { git = "https://github.com/whamcloud/lustre-collector" }
 num-traits = "0.2.14"
 prometheus = "0.13.3"
 prometheus_exporter_base = {version = "1.4.0", features = ["hyper_server"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "lustrefs-exporter"
 version = "0.2.3"
 
 [dependencies]
-lustre_collector = { git = "https://github.com/whamcloud/lustre-collector" }
+lustre_collector = "0.7"
 num-traits = "0.2.14"
 prometheus = "0.13.3"
 prometheus_exporter_base = {version = "1.4.0", features = ["hyper_server"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod brw_stats;
 pub mod jobstats;
 pub mod lnet;
+pub mod service;
 pub mod stats;
 
 use brw_stats::build_target_stats;
@@ -8,6 +9,7 @@ use lnet::build_lnet_stats;
 use lustre_collector::{LNetStat, LNetStatGlobal, Record, TargetStat, TargetVariant};
 use num_traits::Num;
 use prometheus_exporter_base::{prelude::*, Yes};
+use service::build_service_stats;
 use std::{collections::BTreeMap, fmt, ops::Deref, time::Duration};
 
 #[derive(Debug, Clone, Copy)]
@@ -122,6 +124,9 @@ pub fn build_lustre_stats(output: Vec<Record>, time: Duration) -> String {
             }
             lustre_collector::Record::Target(x) => {
                 build_target_stats(x, &mut stats_map, time);
+            }
+            lustre_collector::Record::LustreService(x) => {
+                build_service_stats(x, &mut stats_map, time);
             }
         }
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,8 +1,6 @@
 use std::{collections::BTreeMap, ops::Deref, time::Duration};
-
 use lustre_collector::LustreServiceStats;
 use prometheus_exporter_base::prelude::*;
-
 use crate::{Metric, StatsMapExt};
 
 static LDLM_CANCELD_STATS_SAMPLES: Metric = Metric {

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,7 +1,7 @@
-use std::{collections::BTreeMap, ops::Deref, time::Duration};
+use crate::{Metric, StatsMapExt};
 use lustre_collector::LustreServiceStats;
 use prometheus_exporter_base::prelude::*;
-use crate::{Metric, StatsMapExt};
+use std::{collections::BTreeMap, ops::Deref, time::Duration};
 
 static LDLM_CANCELD_STATS_SAMPLES: Metric = Metric {
     name: "lustre_ldlm_canceld_stats",

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,51 @@
+use std::{collections::BTreeMap, ops::Deref, time::Duration};
+
+use lustre_collector::LustreServiceStats;
+use prometheus_exporter_base::prelude::*;
+
+use crate::{Metric, StatsMapExt};
+
+static LDLM_CANCELD_STATS_SAMPLES: Metric = Metric {
+    name: "lustre_ldlm_canceld_stats",
+    help: "Gives information about LDLM Canceld service.",
+    r#type: MetricType::Counter,
+};
+
+static LDLM_CBD_STATS_SAMPLES: Metric = Metric {
+    name: "lustre_ldlm_cbd_stats",
+    help: "Gives information about LDLM Callback service.",
+    r#type: MetricType::Counter,
+};
+
+pub fn build_service_stats(
+    x: LustreServiceStats,
+    stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
+    time: Duration,
+) {
+    match x {
+        LustreServiceStats::LdlmCanceld(xs) => {
+            for s in xs {
+                stats_map
+                    .get_mut_metric(LDLM_CANCELD_STATS_SAMPLES)
+                    .render_and_append_instance(
+                        &PrometheusInstance::new()
+                            .with_label("operation", s.name.deref())
+                            .with_value(s.samples)
+                            .with_timestamp(time.as_millis()),
+                    );
+            }
+        }
+        LustreServiceStats::LdlmCbd(xs) => {
+            for s in xs {
+                stats_map
+                    .get_mut_metric(LDLM_CBD_STATS_SAMPLES)
+                    .render_and_append_instance(
+                        &PrometheusInstance::new()
+                            .with_label("operation", s.name.deref())
+                            .with_value(s.samples)
+                            .with_timestamp(time.as_millis()),
+                    );
+            }
+        }
+    };
+}


### PR DESCRIPTION
```
# HELP lustre_ldlm_canceld_stats Gives information about LDLM Canceld service.
# TYPE lustre_ldlm_canceld_stats counter
lustre_ldlm_canceld_stats{operation="req_waittime"} 8288250 1688656538723
lustre_ldlm_canceld_stats{operation="req_qdepth"} 8288250 1688656538723
lustre_ldlm_canceld_stats{operation="req_active"} 8288250 1688656538723
lustre_ldlm_canceld_stats{operation="req_timeout"} 8288250 1688656538723
lustre_ldlm_canceld_stats{operation="reqbuf_avail"} 17198642 1688656538723
lustre_ldlm_canceld_stats{operation="ldlm_cancel"} 8288250 1688656538723
# HELP lustre_ldlm_cbd_stats Gives information about LDLM Callback service.
# TYPE lustre_ldlm_cbd_stats counter
lustre_ldlm_cbd_stats{operation="req_waittime"} 3858722 1688656538723
lustre_ldlm_cbd_stats{operation="req_qdepth"} 3858722 1688656538723
lustre_ldlm_cbd_stats{operation="req_active"} 3858722 1688656538723
lustre_ldlm_cbd_stats{operation="req_timeout"} 3858722 1688656538723
lustre_ldlm_cbd_stats{operation="reqbuf_avail"} 7723649 1688656538723
lustre_ldlm_cbd_stats{operation="ldlm_bl_callback"} 1375922 1688656538723
lustre_ldlm_cbd_stats{operation="ldlm_cp_callback"} 2482800 168865653872
```

Draft until there is a new release of https://github.com/whamcloud/lustre-collector/