### PR TITLE
Output '*kilobytes' metrics to KB

### DIFF
--- a/src/brw_stats.rs
+++ b/src/brw_stats.rs
@@ -63,19 +63,19 @@ static INODES_MAXIMUM: Metric = Metric {
     r#type: MetricType::Gauge,
 };
 
-static AVAILABLE_BYTES: Metric = Metric {
+static AVAILABLE_KBYTES: Metric = Metric {
     name: "lustre_available_kilobytes",
     help: "Number of kilobytes readily available in the pool",
     r#type: MetricType::Gauge,
 };
 
-static FREE_BYTES: Metric = Metric {
+static FREE_KBYTES: Metric = Metric {
     name: "lustre_free_kilobytes",
     help: "Number of kilobytes allocated to the pool",
     r#type: MetricType::Gauge,
 };
 
-static CAPACITY_BYTES: Metric = Metric {
+static CAPACITY_KBYTES: Metric = Metric {
     name: "lustre_capacity_kilobytes",
     help: "Capacity of the pool in kilobytes",
     r#type: MetricType::Gauge,
@@ -229,18 +229,36 @@ pub fn build_target_stats(
         }
         TargetStats::FsType(_) => {}
         TargetStats::BytesAvail(x) => {
+            let x = TargetStat {
+                kind: x.kind,
+                param: x.param,
+                target: x.target,
+                value: x.value / 1024,
+            };
             stats_map
-                .get_mut_metric(AVAILABLE_BYTES)
+                .get_mut_metric(AVAILABLE_KBYTES)
                 .render_and_append_instance(&x.to_metric_inst(time));
         }
         TargetStats::BytesFree(x) => {
+            let x = TargetStat {
+                kind: x.kind,
+                param: x.param,
+                target: x.target,
+                value: x.value / 1024,
+            };
             stats_map
-                .get_mut_metric(FREE_BYTES)
+                .get_mut_metric(FREE_KBYTES)
                 .render_and_append_instance(&x.to_metric_inst(time));
         }
         TargetStats::BytesTotal(x) => {
+            let x = TargetStat {
+                kind: x.kind,
+                param: x.param,
+                target: x.target,
+                value: x.value / 1024,
+            };
             stats_map
-                .get_mut_metric(CAPACITY_BYTES)
+                .get_mut_metric(CAPACITY_KBYTES)
                 .render_and_append_instance(&x.to_metric_inst(time));
         }
         TargetStats::NumExports(x) => {

--- a/src/snapshots/lustrefs_exporter__tests__jobstats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__jobstats.snap
@@ -4,17 +4,17 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 474824704 0
-lustre_available_kilobytes{component="mdt",target="fs-MDT0000"} 2423201792 0
-lustre_available_kilobytes{component="ost",target="fs-OST0000"} 4135227392 0
-lustre_available_kilobytes{component="ost",target="fs-OST0001"} 4135227392 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 463696 0
+lustre_available_kilobytes{component="mdt",target="fs-MDT0000"} 2366408 0
+lustre_available_kilobytes{component="ost",target="fs-OST0000"} 4038308 0
+lustre_available_kilobytes{component="ost",target="fs-OST0001"} 4038308 0
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 502878208 0
-lustre_capacity_kilobytes{component="mdt",target="fs-MDT0000"} 2665299968 0
-lustre_capacity_kilobytes{component="ost",target="fs-OST0000"} 4206989312 0
-lustre_capacity_kilobytes{component="ost",target="fs-OST0001"} 4206989312 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 491092 0
+lustre_capacity_kilobytes{component="mdt",target="fs-MDT0000"} 2602832 0
+lustre_capacity_kilobytes{component="ost",target="fs-OST0000"} 4108388 0
+lustre_capacity_kilobytes{component="ost",target="fs-OST0001"} 4108388 0
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
@@ -158,10 +158,10 @@ lustre_exports_total{component="mdt",target="fs-MDT0000"} 10 0
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 501665792 0
-lustre_free_kilobytes{component="mdt",target="fs-MDT0000"} 2662928384 0
-lustre_free_kilobytes{component="ost",target="fs-OST0000"} 4205690880 0
-lustre_free_kilobytes{component="ost",target="fs-OST0001"} 4205690880 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 489908 0
+lustre_free_kilobytes{component="mdt",target="fs-MDT0000"} 2600516 0
+lustre_free_kilobytes{component="ost",target="fs-OST0000"} 4107120 0
+lustre_free_kilobytes{component="ost",target="fs-OST0001"} 4107120 0
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge

--- a/src/snapshots/lustrefs_exporter__tests__lnetctl_stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__lnetctl_stats.snap
@@ -4,17 +4,17 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 1918787584 0
-lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 429908463616 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 2035205947392 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 935672266752 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 1873816 0
+lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 419832484 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 1987505808 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 913742448 0
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 2027556864 0
-lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437423087616 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 35584435134464 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 35584435134464 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036 0
+lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427170984 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 34750424936 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 34750424936 0
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
@@ -239,10 +239,10 @@ lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 32 0
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 2026160128 0
-lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437329862656 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 2395312779264 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 1295779098624 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 1978672 0
+lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427079944 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 2339172636 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 1265409276 0
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge

--- a/src/snapshots/lustrefs_exporter__tests__stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__stats.snap
@@ -4,17 +4,17 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 1918767104 0
-lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 142034284544 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 3334853013504 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 3335272443904 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 1873796 0
+lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 138705356 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 3256692396 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 3257101996 0
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 2027556864 0
-lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 144541634560 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 3544070828032 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 3544070828032 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036 0
+lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 141153940 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 3461006668 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 3461006668 0
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
@@ -104,10 +104,10 @@ lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 19 0
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 2026139648 0
-lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 144535597056 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 3541028220928 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 3541447651328 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 1978652 0
+lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 141148044 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 3458035372 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 3458444972 0
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge


### PR DESCRIPTION
Fixes [EX-7902](https://jira.whamcloud.com/browse/EX-7902)

# Demo
get_param:
```
[root@ai400-001 ~]# lctl  get_param osd-*.*.kbytesavail
osd-ldiskfs.MGS.kbytesavail=1874028
osd-ldiskfs.testfs-MDT0000.kbytesavail=3388879012
[root@ai400-001 ~]# lctl get_param osd-*.*.kbytesfree
osd-ldiskfs.MGS.kbytesfree=1978884
osd-ldiskfs.testfs-MDT0000.kbytesfree=3446861004
[root@ai400-001 ~]# lctl get_param osd-*.*.kbytestotal
osd-ldiskfs.MGS.kbytestotal=1980036
osd-ldiskfs.testfs-MDT0000.kbytestotal=3446866632
```
exporter:
```
# HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
# TYPE lustre_available_kilobytes gauge
lustre_available_kilobytes{component="mgt",target="MGS"} 1874028 1689664819761
lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 3388879012 1689664819761

# HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
# TYPE lustre_free_kilobytes gauge
lustre_free_kilobytes{component="mgt",target="MGS"} 1978884 1689664819761
lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 3446861004 1689664819761

# HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
# TYPE lustre_capacity_kilobytes gauge
lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036 1689664819761
lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 3446866632 1689664819761
```