### PR TITLE
Add OSS stats

### DIFF
--- a/fixtures/stats.json
+++ b/fixtures/stats.json
@@ -3,7 +3,7 @@
     "Host": {
       "Memused": {
         "param": "memused",
-        "value": 1196193562
+        "value": 1601002785
       }
     }
   },
@@ -11,7 +11,7 @@
     "Host": {
       "MemusedMax": {
         "param": "memused_max",
-        "value": 3079541109
+        "value": 1611219801
       }
     }
   },
@@ -19,7 +19,7 @@
     "Host": {
       "LNetMemUsed": {
         "param": "lnet_memused",
-        "value": 154189179
+        "value": 174323852
       }
     }
   },
@@ -37,7 +37,7 @@
         "kind": "Mdt",
         "param": "connected_clients",
         "target": "ai400x2-MDT0000",
-        "value": 4
+        "value": 1
       }
     }
   },
@@ -57,7 +57,7 @@
         "kind": "Mdt",
         "param": "filesfree",
         "target": "ai400x2-MDT0000",
-        "value": 97713887
+        "value": 289887431
       }
     }
   },
@@ -67,7 +67,7 @@
         "kind": "Ost",
         "param": "filesfree",
         "target": "ai400x2-OST0000",
-        "value": 1073740846
+        "value": 274725135
       }
     }
   },
@@ -77,7 +77,7 @@
         "kind": "Ost",
         "param": "filesfree",
         "target": "ai400x2-OST0001",
-        "value": 1073740847
+        "value": 274725134
       }
     }
   },
@@ -97,7 +97,7 @@
         "kind": "Mdt",
         "param": "filestotal",
         "target": "ai400x2-MDT0000",
-        "value": 97714176
+        "value": 289887952
       }
     }
   },
@@ -107,7 +107,7 @@
         "kind": "Ost",
         "param": "filestotal",
         "target": "ai400x2-OST0000",
-        "value": 1073741824
+        "value": 274726912
       }
     }
   },
@@ -117,7 +117,7 @@
         "kind": "Ost",
         "param": "filestotal",
         "target": "ai400x2-OST0001",
-        "value": 1073741824
+        "value": 274726912
       }
     }
   },
@@ -167,7 +167,7 @@
         "kind": "Mgt",
         "param": "kbytesavail",
         "target": "MGS",
-        "value": 1918767104
+        "value": 1873772
       }
     }
   },
@@ -177,7 +177,7 @@
         "kind": "Mdt",
         "param": "kbytesavail",
         "target": "ai400x2-MDT0000",
-        "value": 142034284544
+        "value": 419917436
       }
     }
   },
@@ -187,7 +187,7 @@
         "kind": "Ost",
         "param": "kbytesavail",
         "target": "ai400x2-OST0000",
-        "value": 3334853013504
+        "value": 34187914484
       }
     }
   },
@@ -197,7 +197,7 @@
         "kind": "Ost",
         "param": "kbytesavail",
         "target": "ai400x2-OST0001",
-        "value": 3335272443904
+        "value": 34188706564
       }
     }
   },
@@ -207,7 +207,7 @@
         "kind": "Mgt",
         "param": "kbytesfree",
         "target": "MGS",
-        "value": 2026139648
+        "value": 1978628
       }
     }
   },
@@ -217,7 +217,7 @@
         "kind": "Mdt",
         "param": "kbytesfree",
         "target": "ai400x2-MDT0000",
-        "value": 144535597056
+        "value": 427164896
       }
     }
   },
@@ -227,7 +227,7 @@
         "kind": "Ost",
         "param": "kbytesfree",
         "target": "ai400x2-OST0000",
-        "value": 3541028220928
+        "value": 34539581312
       }
     }
   },
@@ -237,7 +237,7 @@
         "kind": "Ost",
         "param": "kbytesfree",
         "target": "ai400x2-OST0001",
-        "value": 3541447651328
+        "value": 34540373392
       }
     }
   },
@@ -247,7 +247,7 @@
         "kind": "Mgt",
         "param": "kbytestotal",
         "target": "MGS",
-        "value": 2027556864
+        "value": 1980036
       }
     }
   },
@@ -257,7 +257,7 @@
         "kind": "Mdt",
         "param": "kbytestotal",
         "target": "ai400x2-MDT0000",
-        "value": 144541634560
+        "value": 427170984
       }
     }
   },
@@ -267,7 +267,7 @@
         "kind": "Ost",
         "param": "kbytestotal",
         "target": "ai400x2-OST0000",
-        "value": 3544070828032
+        "value": 34750424936
       }
     }
   },
@@ -277,7 +277,7 @@
         "kind": "Ost",
         "param": "kbytestotal",
         "target": "ai400x2-OST0001",
-        "value": 3544070828032
+        "value": 34750424936
       }
     }
   },
@@ -385,9 +385,49 @@
             "unit": "rpcs",
             "buckets": [
               {
+                "name": 1,
+                "read": 45221,
+                "write": 192
+              },
+              {
+                "name": 2,
+                "read": 807,
+                "write": 67
+              },
+              {
+                "name": 4,
+                "read": 341,
+                "write": 262
+              },
+              {
+                "name": 8,
+                "read": 818,
+                "write": 262
+              },
+              {
+                "name": 16,
+                "read": 1382,
+                "write": 728
+              },
+              {
+                "name": 32,
+                "read": 3718,
+                "write": 1548
+              },
+              {
+                "name": 64,
+                "read": 5363,
+                "write": 2295
+              },
+              {
+                "name": 128,
+                "read": 7996,
+                "write": 3506
+              },
+              {
                 "name": 256,
-                "read": 0,
-                "write": 2
+                "read": 9230582,
+                "write": 4068108
               },
               {
                 "name": 512,
@@ -396,8 +436,18 @@
               },
               {
                 "name": 1024,
-                "read": 0,
-                "write": 736
+                "read": 50,
+                "write": 3411
+              },
+              {
+                "name": 2048,
+                "read": 11,
+                "write": 2509
+              },
+              {
+                "name": 4096,
+                "read": 55774,
+                "write": 40752
               }
             ]
           },
@@ -407,8 +457,18 @@
             "buckets": [
               {
                 "name": 0,
-                "read": 0,
-                "write": 738
+                "read": 9351652,
+                "write": 4114231
+              },
+              {
+                "name": 1,
+                "read": 409,
+                "write": 9407
+              },
+              {
+                "name": 2,
+                "read": 2,
+                "write": 2
               }
             ]
           },
@@ -418,81 +478,43 @@
             "buckets": [
               {
                 "name": 0,
-                "read": 0,
-                "write": 738
-              }
-            ]
-          },
-          {
-            "name": "dio_frags",
-            "unit": "ios",
-            "buckets": [
+                "read": 9292664,
+                "write": 4072612
+              },
               {
                 "name": 1,
-                "read": 0,
-                "write": 2
+                "read": 42047,
+                "write": 28493
               },
               {
                 "name": 2,
-                "read": 0,
-                "write": 0
+                "read": 17352,
+                "write": 21665
               },
               {
                 "name": 3,
                 "read": 0,
-                "write": 0
+                "write": 687
               },
               {
                 "name": 4,
                 "read": 0,
-                "write": 736
-              }
-            ]
-          },
-          {
-            "name": "rpc_hist",
-            "unit": "ios",
-            "buckets": [
-              {
-                "name": 1,
-                "read": 0,
-                "write": 738
+                "write": 137
               },
               {
-                "name": 2,
+                "name": 5,
                 "read": 0,
-                "write": 736
+                "write": 27
               },
               {
-                "name": 3,
+                "name": 6,
                 "read": 0,
-                "write": 736
+                "write": 13
               },
               {
-                "name": 4,
+                "name": 7,
                 "read": 0,
-                "write": 736
-              }
-            ]
-          },
-          {
-            "name": "io_time",
-            "unit": "ios",
-            "buckets": [
-              {
-                "name": 1,
-                "read": 0,
-                "write": 734
-              },
-              {
-                "name": 2,
-                "read": 0,
-                "write": 0
-              },
-              {
-                "name": 4,
-                "read": 0,
-                "write": 3
+                "write": 5
               },
               {
                 "name": 8,
@@ -502,13 +524,311 @@
             ]
           },
           {
+            "name": "dio_frags",
+            "unit": "ios",
+            "buckets": [
+              {
+                "name": 1,
+                "read": 9292607,
+                "write": 4076945
+              },
+              {
+                "name": 2,
+                "read": 3669,
+                "write": 3434
+              },
+              {
+                "name": 3,
+                "read": 2,
+                "write": 0
+              },
+              {
+                "name": 4,
+                "read": 11,
+                "write": 2509
+              },
+              {
+                "name": 5,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 6,
+                "read": 6,
+                "write": 2041
+              },
+              {
+                "name": 7,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 8,
+                "read": 55768,
+                "write": 38711
+              }
+            ]
+          },
+          {
+            "name": "rpc_hist",
+            "unit": "ios",
+            "buckets": [
+              {
+                "name": 1,
+                "read": 2499387,
+                "write": 1187036
+              },
+              {
+                "name": 2,
+                "read": 1883945,
+                "write": 793707
+              },
+              {
+                "name": 3,
+                "read": 1493683,
+                "write": 503920
+              },
+              {
+                "name": 4,
+                "read": 1058167,
+                "write": 395381
+              },
+              {
+                "name": 5,
+                "read": 704804,
+                "write": 288275
+              },
+              {
+                "name": 6,
+                "read": 495027,
+                "write": 197769
+              },
+              {
+                "name": 7,
+                "read": 356780,
+                "write": 132864
+              },
+              {
+                "name": 8,
+                "read": 256413,
+                "write": 89052
+              },
+              {
+                "name": 9,
+                "read": 181632,
+                "write": 58501
+              },
+              {
+                "name": 10,
+                "read": 123818,
+                "write": 26704
+              },
+              {
+                "name": 11,
+                "read": 90035,
+                "write": 14119
+              },
+              {
+                "name": 12,
+                "read": 68887,
+                "write": 8829
+              },
+              {
+                "name": 13,
+                "read": 55465,
+                "write": 6550
+              },
+              {
+                "name": 14,
+                "read": 45232,
+                "write": 5547
+              },
+              {
+                "name": 15,
+                "read": 38000,
+                "write": 5383
+              },
+              {
+                "name": 16,
+                "read": 31971,
+                "write": 5481
+              },
+              {
+                "name": 17,
+                "read": 25211,
+                "write": 6177
+              },
+              {
+                "name": 18,
+                "read": 21467,
+                "write": 6767
+              },
+              {
+                "name": 19,
+                "read": 18780,
+                "write": 8074
+              },
+              {
+                "name": 20,
+                "read": 16625,
+                "write": 9646
+              },
+              {
+                "name": 21,
+                "read": 15098,
+                "write": 12313
+              },
+              {
+                "name": 22,
+                "read": 13849,
+                "write": 15267
+              },
+              {
+                "name": 23,
+                "read": 13017,
+                "write": 19877
+              },
+              {
+                "name": 24,
+                "read": 12337,
+                "write": 24453
+              },
+              {
+                "name": 25,
+                "read": 11413,
+                "write": 30315
+              },
+              {
+                "name": 26,
+                "read": 11028,
+                "write": 34324
+              },
+              {
+                "name": 27,
+                "read": 10704,
+                "write": 37750
+              },
+              {
+                "name": 28,
+                "read": 10471,
+                "write": 38776
+              },
+              {
+                "name": 29,
+                "read": 10297,
+                "write": 38871
+              },
+              {
+                "name": 30,
+                "read": 10119,
+                "write": 36556
+              },
+              {
+                "name": 31,
+                "read": 162513,
+                "write": 377499
+              }
+            ]
+          },
+          {
+            "name": "io_time",
+            "unit": "ios",
+            "buckets": [
+              {
+                "name": 1,
+                "read": 9244557,
+                "write": 3616861
+              },
+              {
+                "name": 2,
+                "read": 45925,
+                "write": 83848
+              },
+              {
+                "name": 4,
+                "read": 30611,
+                "write": 314948
+              },
+              {
+                "name": 8,
+                "read": 26141,
+                "write": 49922
+              },
+              {
+                "name": 16,
+                "read": 4808,
+                "write": 51585
+              },
+              {
+                "name": 32,
+                "read": 14,
+                "write": 6394
+              },
+              {
+                "name": 64,
+                "read": 6,
+                "write": 82
+              },
+              {
+                "name": 128,
+                "read": 1,
+                "write": 0
+              }
+            ]
+          },
+          {
             "name": "disk_iosize",
             "unit": "ios",
             "buckets": [
               {
+                "name": 4096,
+                "read": 48747,
+                "write": 9253
+              },
+              {
+                "name": 8192,
+                "read": 808,
+                "write": 24
+              },
+              {
+                "name": 16384,
+                "read": 342,
+                "write": 144
+              },
+              {
+                "name": 32768,
+                "read": 819,
+                "write": 129
+              },
+              {
+                "name": 65536,
+                "read": 1394,
+                "write": 344
+              },
+              {
+                "name": 131072,
+                "read": 3731,
+                "write": 777
+              },
+              {
+                "name": 262144,
+                "read": 5397,
+                "write": 1152
+              },
+              {
+                "name": 524288,
+                "read": 8031,
+                "write": 1759
+              },
+              {
                 "name": 1048576,
-                "read": 0,
-                "write": 2946
+                "read": 9230582,
+                "write": 4063409
+              },
+              {
+                "name": 2097152,
+                "read": 446324,
+                "write": 338792
               }
             ]
           }
@@ -528,9 +848,69 @@
             "unit": "rpcs",
             "buckets": [
               {
-                "name": 1024,
+                "name": 1,
+                "read": 46495,
+                "write": 208
+              },
+              {
+                "name": 2,
+                "read": 709,
+                "write": 85
+              },
+              {
+                "name": 4,
+                "read": 281,
+                "write": 248
+              },
+              {
+                "name": 8,
+                "read": 867,
+                "write": 281
+              },
+              {
+                "name": 16,
+                "read": 1396,
+                "write": 702
+              },
+              {
+                "name": 32,
+                "read": 3421,
+                "write": 1478
+              },
+              {
+                "name": 64,
+                "read": 5613,
+                "write": 2418
+              },
+              {
+                "name": 128,
+                "read": 7951,
+                "write": 3519
+              },
+              {
+                "name": 256,
+                "read": 9191867,
+                "write": 4072014
+              },
+              {
+                "name": 512,
                 "read": 0,
-                "write": 625
+                "write": 0
+              },
+              {
+                "name": 1024,
+                "read": 46,
+                "write": 3569
+              },
+              {
+                "name": 2048,
+                "read": 14,
+                "write": 2603
+              },
+              {
+                "name": 4096,
+                "read": 57301,
+                "write": 41094
               }
             ]
           },
@@ -540,8 +920,18 @@
             "buckets": [
               {
                 "name": 0,
+                "read": 9315526,
+                "write": 4118794
+              },
+              {
+                "name": 1,
+                "read": 435,
+                "write": 9423
+              },
+              {
+                "name": 2,
                 "read": 0,
-                "write": 625
+                "write": 2
               }
             ]
           },
@@ -551,8 +941,163 @@
             "buckets": [
               {
                 "name": 0,
+                "read": 9254895,
+                "write": 4076814
+              },
+              {
+                "name": 1,
+                "read": 41231,
+                "write": 28934
+              },
+              {
+                "name": 2,
+                "read": 19835,
+                "write": 21641
+              },
+              {
+                "name": 3,
                 "read": 0,
-                "write": 625
+                "write": 635
+              },
+              {
+                "name": 4,
+                "read": 0,
+                "write": 146
+              },
+              {
+                "name": 5,
+                "read": 0,
+                "write": 33
+              },
+              {
+                "name": 6,
+                "read": 0,
+                "write": 12
+              },
+              {
+                "name": 7,
+                "read": 0,
+                "write": 3
+              },
+              {
+                "name": 8,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 9,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 10,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 11,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 12,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 13,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 14,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 15,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 16,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 17,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 18,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 19,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 20,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 21,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 22,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 23,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 24,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 25,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 26,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 27,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 28,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 29,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 30,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 31,
+                "read": 0,
+                "write": 1
               }
             ]
           },
@@ -561,9 +1106,44 @@
             "unit": "ios",
             "buckets": [
               {
+                "name": 1,
+                "read": 9254837,
+                "write": 4080923
+              },
+              {
+                "name": 2,
+                "read": 3808,
+                "write": 3599
+              },
+              {
+                "name": 3,
+                "read": 1,
+                "write": 0
+              },
+              {
                 "name": 4,
+                "read": 14,
+                "write": 2603
+              },
+              {
+                "name": 5,
                 "read": 0,
-                "write": 625
+                "write": 0
+              },
+              {
+                "name": 6,
+                "read": 7,
+                "write": 2055
+              },
+              {
+                "name": 7,
+                "read": 0,
+                "write": 0
+              },
+              {
+                "name": 8,
+                "read": 57294,
+                "write": 39039
               }
             ]
           },
@@ -573,23 +1153,158 @@
             "buckets": [
               {
                 "name": 1,
-                "read": 0,
-                "write": 625
+                "read": 2488039,
+                "write": 1185285
               },
               {
                 "name": 2,
-                "read": 0,
-                "write": 625
+                "read": 1873744,
+                "write": 787309
               },
               {
                 "name": 3,
-                "read": 0,
-                "write": 625
+                "read": 1490244,
+                "write": 498673
               },
               {
                 "name": 4,
-                "read": 0,
-                "write": 625
+                "read": 1058749,
+                "write": 395423
+              },
+              {
+                "name": 5,
+                "read": 704439,
+                "write": 291932
+              },
+              {
+                "name": 6,
+                "read": 495012,
+                "write": 201902
+              },
+              {
+                "name": 7,
+                "read": 357583,
+                "write": 137081
+              },
+              {
+                "name": 8,
+                "read": 255910,
+                "write": 91340
+              },
+              {
+                "name": 9,
+                "read": 181672,
+                "write": 59739
+              },
+              {
+                "name": 10,
+                "read": 122401,
+                "write": 27549
+              },
+              {
+                "name": 11,
+                "read": 88149,
+                "write": 14513
+              },
+              {
+                "name": 12,
+                "read": 67154,
+                "write": 9077
+              },
+              {
+                "name": 13,
+                "read": 53823,
+                "write": 6688
+              },
+              {
+                "name": 14,
+                "read": 44023,
+                "write": 5725
+              },
+              {
+                "name": 15,
+                "read": 37170,
+                "write": 5530
+              },
+              {
+                "name": 16,
+                "read": 31368,
+                "write": 5664
+              },
+              {
+                "name": 17,
+                "read": 24929,
+                "write": 6440
+              },
+              {
+                "name": 18,
+                "read": 21347,
+                "write": 7087
+              },
+              {
+                "name": 19,
+                "read": 18674,
+                "write": 8465
+              },
+              {
+                "name": 20,
+                "read": 16527,
+                "write": 10044
+              },
+              {
+                "name": 21,
+                "read": 15156,
+                "write": 12647
+              },
+              {
+                "name": 22,
+                "read": 14051,
+                "write": 15863
+              },
+              {
+                "name": 23,
+                "read": 13243,
+                "write": 20105
+              },
+              {
+                "name": 24,
+                "read": 12577,
+                "write": 24737
+              },
+              {
+                "name": 25,
+                "read": 11661,
+                "write": 30564
+              },
+              {
+                "name": 26,
+                "read": 11371,
+                "write": 34765
+              },
+              {
+                "name": 27,
+                "read": 11019,
+                "write": 37755
+              },
+              {
+                "name": 28,
+                "read": 10843,
+                "write": 38708
+              },
+              {
+                "name": 29,
+                "read": 10656,
+                "write": 38610
+              },
+              {
+                "name": 30,
+                "read": 10512,
+                "write": 36144
+              },
+              {
+                "name": 31,
+                "read": 168860,
+                "write": 377811
               }
             ]
           },
@@ -599,28 +1314,38 @@
             "buckets": [
               {
                 "name": 1,
-                "read": 0,
-                "write": 621
+                "read": 9207507,
+                "write": 3621675
               },
               {
                 "name": 2,
-                "read": 0,
-                "write": 0
+                "read": 45907,
+                "write": 83387
               },
               {
                 "name": 4,
-                "read": 0,
-                "write": 0
+                "read": 31151,
+                "write": 314557
               },
               {
                 "name": 8,
-                "read": 0,
-                "write": 1
+                "read": 26619,
+                "write": 50234
               },
               {
                 "name": 16,
-                "read": 0,
-                "write": 3
+                "read": 4762,
+                "write": 52033
+              },
+              {
+                "name": 32,
+                "read": 9,
+                "write": 6238
+              },
+              {
+                "name": 64,
+                "read": 6,
+                "write": 95
               }
             ]
           },
@@ -629,9 +1354,54 @@
             "unit": "ios",
             "buckets": [
               {
+                "name": 4096,
+                "read": 50197,
+                "write": 9280
+              },
+              {
+                "name": 8192,
+                "read": 710,
+                "write": 28
+              },
+              {
+                "name": 16384,
+                "read": 281,
+                "write": 125
+              },
+              {
+                "name": 32768,
+                "read": 867,
+                "write": 148
+              },
+              {
+                "name": 65536,
+                "read": 1407,
+                "write": 329
+              },
+              {
+                "name": 131072,
+                "read": 3430,
+                "write": 741
+              },
+              {
+                "name": 262144,
+                "read": 5639,
+                "write": 1216
+              },
+              {
+                "name": 524288,
+                "read": 7966,
+                "write": 1763
+              },
+              {
                 "name": 1048576,
-                "read": 0,
-                "write": 2500
+                "read": 9191867,
+                "write": 4067353
+              },
+              {
+                "name": 2097152,
+                "read": 458542,
+                "write": 342192
               }
             ]
           }
@@ -645,7 +1415,7 @@
         "kind": "Mdt",
         "param": "connected_clients",
         "target": "ai400x2-MDT0000",
-        "value": 4
+        "value": 1
       }
     }
   },
@@ -659,128 +1429,128 @@
           {
             "name": "req_waittime",
             "units": "usec",
-            "samples": 303452,
-            "min": 9,
-            "max": 31310,
-            "sum": 14749340,
-            "sumsquare": 62979167740
+            "samples": 41486,
+            "min": 7,
+            "max": 48373,
+            "sum": 4436399,
+            "sumsquare": 66817492203
           },
           {
             "name": "req_qdepth",
             "units": "reqs",
-            "samples": 303452,
+            "samples": 41486,
             "min": 0,
-            "max": 0,
-            "sum": 0,
-            "sumsquare": 0
+            "max": 1,
+            "sum": 33,
+            "sumsquare": 33
           },
           {
             "name": "req_active",
             "units": "reqs",
-            "samples": 303452,
+            "samples": 41486,
             "min": 1,
             "max": 3,
-            "sum": 303491,
-            "sumsquare": 303573
+            "sum": 47679,
+            "sumsquare": 60067
           },
           {
             "name": "req_timeout",
             "units": "sec",
-            "samples": 303452,
+            "samples": 41486,
             "min": 1,
-            "max": 31,
-            "sum": 305891,
-            "sumsquare": 381311
+            "max": 15,
+            "sum": 616475,
+            "sumsquare": 9241265
           },
           {
             "name": "reqbuf_avail",
             "units": "bufs",
-            "samples": 854571,
+            "samples": 86048,
             "min": 61,
             "max": 64,
-            "sum": 54085896,
-            "sumsquare": 3423278802
+            "sum": 5394829,
+            "sumsquare": 338250681
           },
           {
             "name": "ldlm_plain_enqueue",
             "units": "reqs",
-            "samples": 297,
+            "samples": 379,
             "min": 1,
             "max": 1,
-            "sum": 297,
-            "sumsquare": 297
+            "sum": 379,
+            "sumsquare": 379
           },
           {
             "name": "mgs_connect",
             "units": "usec",
-            "samples": 13,
-            "min": 23,
-            "max": 95,
-            "sum": 809,
-            "sumsquare": 55405
+            "samples": 8,
+            "min": 34,
+            "max": 77,
+            "sum": 419,
+            "sumsquare": 22987
           },
           {
             "name": "mgs_disconnect",
             "units": "usec",
-            "samples": 9,
-            "min": 14,
-            "max": 65,
-            "sum": 329,
-            "sumsquare": 14411
+            "samples": 2,
+            "min": 31,
+            "max": 36,
+            "sum": 67,
+            "sumsquare": 2257
           },
           {
             "name": "mgs_target_reg",
             "units": "usec",
-            "samples": 116,
+            "samples": 20,
             "min": 11,
-            "max": 3191,
-            "sum": 39241,
-            "sumsquare": 52795125
+            "max": 331,
+            "sum": 2706,
+            "sumsquare": 595784
           },
           {
             "name": "mgs_config_read",
             "units": "usec",
-            "samples": 56,
-            "min": 29,
-            "max": 15714,
-            "sum": 21490,
-            "sumsquare": 247662642
+            "samples": 14,
+            "min": 33,
+            "max": 205,
+            "sum": 1315,
+            "sumsquare": 161729
           },
           {
             "name": "obd_ping",
             "units": "usec",
-            "samples": 302013,
-            "min": 3,
-            "max": 46346,
-            "sum": 7305740,
-            "sumsquare": 29927097856
+            "samples": 39853,
+            "min": 2,
+            "max": 46832,
+            "sum": 2578221,
+            "sumsquare": 42371052125
           },
           {
             "name": "llog_origin_handle_open",
             "units": "usec",
-            "samples": 220,
-            "min": 6,
-            "max": 425,
-            "sum": 4832,
-            "sumsquare": 314198
+            "samples": 360,
+            "min": 5,
+            "max": 1355,
+            "sum": 6847,
+            "sumsquare": 2147729
           },
           {
             "name": "llog_origin_handle_next_block",
             "units": "usec",
-            "samples": 524,
-            "min": 7,
-            "max": 40,
-            "sum": 7563,
-            "sumsquare": 130875
+            "samples": 532,
+            "min": 6,
+            "max": 275,
+            "sum": 12196,
+            "sumsquare": 1492540
           },
           {
             "name": "llog_origin_handle_read_header",
             "units": "usec",
-            "samples": 204,
-            "min": 8,
-            "max": 46,
-            "sum": 3416,
-            "sumsquare": 68178
+            "samples": 318,
+            "min": 6,
+            "max": 293,
+            "sum": 7446,
+            "sumsquare": 1063150
           }
         ]
       }
@@ -822,7 +1592,7 @@
         "kind": "Mgt",
         "param": "num_exports",
         "target": "MGS",
-        "value": 4
+        "value": 6
       }
     }
   },
@@ -854,67 +1624,103 @@
         "target": "ai400x2-OST0000",
         "value": [
           {
+            "name": "read_bytes",
+            "units": "bytes",
+            "samples": 9352060,
+            "min": 4096,
+            "max": 16777216,
+            "sum": 10614117224448,
+            "sumsquare": 7393889699900686336
+          },
+          {
             "name": "write_bytes",
             "units": "bytes",
-            "samples": 738,
-            "min": 1048576,
-            "max": 4194304,
-            "sum": 3089104896,
-            "sumsquare": 12950047951945728
+            "samples": 4114603,
+            "min": 183,
+            "max": 16777216,
+            "sum": 4971114377425,
+            "sumsquare": 15921893747369135927
+          },
+          {
+            "name": "read",
+            "units": "usecs",
+            "samples": 9352060,
+            "min": 18,
+            "max": 66767,
+            "sum": 8475506312,
+            "sumsquare": 17311638021000
           },
           {
             "name": "write",
             "units": "usecs",
-            "samples": 738,
-            "min": 151,
-            "max": 1240,
-            "sum": 406194,
-            "sumsquare": 232534590
+            "samples": 4114603,
+            "min": 2,
+            "max": 68119,
+            "sum": 1678932253,
+            "sumsquare": 1403596852083
           },
           {
             "name": "punch",
             "units": "usecs",
-            "samples": 4,
-            "min": 182,
-            "max": 3935,
-            "sum": 4865,
-            "sumsquare": 15852213
+            "samples": 31,
+            "min": 16,
+            "max": 697,
+            "sum": 2155,
+            "sumsquare": 782325
+          },
+          {
+            "name": "sync",
+            "units": "usecs",
+            "samples": 28,
+            "min": 0,
+            "max": 3747,
+            "sum": 8832,
+            "sumsquare": 15468294
+          },
+          {
+            "name": "destroy",
+            "units": "usecs",
+            "samples": 7681,
+            "min": 40,
+            "max": 16193,
+            "sum": 4065089,
+            "sumsquare": 8546659631
           },
           {
             "name": "create",
             "units": "usecs",
-            "samples": 8,
+            "samples": 289,
             "min": 1,
-            "max": 5707,
-            "sum": 20519,
-            "sumsquare": 106824119
+            "max": 2206,
+            "sum": 101519,
+            "sumsquare": 44866565
           },
           {
             "name": "statfs",
             "units": "usecs",
-            "samples": 1031857,
+            "samples": 122497,
             "min": 0,
-            "max": 79,
-            "sum": 3558535,
-            "sumsquare": 20245539
+            "max": 46132,
+            "sum": 613392,
+            "sumsquare": 3254812084
           },
           {
             "name": "get_info",
             "units": "usecs",
             "samples": 4,
-            "min": 377,
-            "max": 757,
-            "sum": 2091,
-            "sumsquare": 1186063
+            "min": 723,
+            "max": 5778,
+            "sum": 7955,
+            "sumsquare": 34965073
           },
           {
             "name": "set_info",
             "units": "usecs",
-            "samples": 2,
-            "min": 8,
-            "max": 18,
-            "sum": 26,
-            "sumsquare": 388
+            "samples": 8,
+            "min": 3,
+            "max": 11,
+            "sum": 71,
+            "sumsquare": 687
           }
         ]
       }
@@ -928,67 +1734,103 @@
         "target": "ai400x2-OST0001",
         "value": [
           {
+            "name": "read_bytes",
+            "units": "bytes",
+            "samples": 9315947,
+            "min": 4096,
+            "max": 16777216,
+            "sum": 10599265554432,
+            "sumsquare": 7781353419029086208
+          },
+          {
             "name": "write_bytes",
             "units": "bytes",
-            "samples": 625,
-            "min": 4194304,
-            "max": 4194304,
-            "sum": 2621440000,
-            "sumsquare": 10995116277760000
+            "samples": 4119187,
+            "min": 183,
+            "max": 16777216,
+            "sum": 4982409908141,
+            "sumsquare": 16030200894436904983
+          },
+          {
+            "name": "read",
+            "units": "usecs",
+            "samples": 9315947,
+            "min": 19,
+            "max": 65425,
+            "sum": 8478868967,
+            "sumsquare": 17416751612153
           },
           {
             "name": "write",
             "units": "usecs",
-            "samples": 625,
-            "min": 405,
-            "max": 28101,
-            "sum": 372440,
-            "sumsquare": 986024330
+            "samples": 4119187,
+            "min": 2,
+            "max": 64436,
+            "sum": 1676141801,
+            "sumsquare": 1388228758619
+          },
+          {
+            "name": "punch",
+            "units": "usecs",
+            "samples": 28,
+            "min": 13,
+            "max": 497,
+            "sum": 1067,
+            "sumsquare": 259627
+          },
+          {
+            "name": "sync",
+            "units": "usecs",
+            "samples": 28,
+            "min": 0,
+            "max": 3680,
+            "sum": 8374,
+            "sumsquare": 14946056
           },
           {
             "name": "destroy",
             "units": "usecs",
-            "samples": 1,
-            "min": 294,
-            "max": 294,
-            "sum": 294,
-            "sumsquare": 86436
+            "samples": 7680,
+            "min": 47,
+            "max": 16360,
+            "sum": 4073496,
+            "sumsquare": 8670965576
           },
           {
             "name": "create",
             "units": "usecs",
-            "samples": 8,
-            "min": 1,
-            "max": 4007,
-            "sum": 14738,
-            "sumsquare": 54396988
+            "samples": 289,
+            "min": 2,
+            "max": 2895,
+            "sum": 104936,
+            "sumsquare": 51638974
           },
           {
             "name": "statfs",
             "units": "usecs",
-            "samples": 1031855,
+            "samples": 122497,
             "min": 0,
-            "max": 85,
-            "sum": 3737453,
-            "sumsquare": 22029863
+            "max": 31296,
+            "sum": 560743,
+            "sumsquare": 1163174149
           },
           {
             "name": "get_info",
             "units": "usecs",
             "samples": 4,
-            "min": 379,
-            "max": 424,
-            "sum": 1584,
-            "sumsquare": 628578
+            "min": 631,
+            "max": 4625,
+            "sum": 6553,
+            "sumsquare": 22629915
           },
           {
             "name": "set_info",
             "units": "usecs",
-            "samples": 3,
-            "min": 7,
-            "max": 18,
-            "sum": 34,
-            "sumsquare": 454
+            "samples": 12,
+            "min": 3,
+            "max": 12,
+            "sum": 111,
+            "sumsquare": 1135
           }
         ]
       }
@@ -1040,7 +1882,7 @@
         "kind": "Ost",
         "param": "tot_granted",
         "target": "ai400x2-OST0000",
-        "value": 276416
+        "value": 143424
       }
     }
   },
@@ -1050,7 +1892,7 @@
         "kind": "Ost",
         "param": "tot_granted",
         "target": "ai400x2-OST0001",
-        "value": 276416
+        "value": 143424
       }
     }
   },
@@ -1076,361 +1918,451 @@
   },
   {
     "Target": {
-      "ContendedLocks": {
-        "kind": "Mdt",
-        "param": "contended_locks",
-        "target": "ai400x2-MDT0000",
-        "value": 32
+      "Oss": {
+        "param": "ost",
+        "stats": [
+          {
+            "name": "req_waittime",
+            "units": "usec",
+            "samples": 77655,
+            "min": 3,
+            "max": 15952,
+            "sum": 2114553,
+            "sumsquare": 2370684671
+          },
+          {
+            "name": "req_qdepth",
+            "units": "reqs",
+            "samples": 77655,
+            "min": 0,
+            "max": 3,
+            "sum": 167,
+            "sumsquare": 195
+          },
+          {
+            "name": "req_active",
+            "units": "reqs",
+            "samples": 77655,
+            "min": 1,
+            "max": 16,
+            "sum": 165685,
+            "sumsquare": 859411
+          },
+          {
+            "name": "req_timeout",
+            "units": "sec",
+            "samples": 77655,
+            "min": 1,
+            "max": 15,
+            "sum": 1164317,
+            "sumsquare": 17463707
+          },
+          {
+            "name": "reqbuf_avail",
+            "units": "bufs",
+            "samples": 157527,
+            "min": 62,
+            "max": 64,
+            "sum": 10069194,
+            "sumsquare": 643638790
+          },
+          {
+            "name": "ldlm_glimpse_enqueue",
+            "units": "reqs",
+            "samples": 42486,
+            "min": 1,
+            "max": 1,
+            "sum": 42486,
+            "sumsquare": 42486
+          },
+          {
+            "name": "ldlm_extent_enqueue",
+            "units": "reqs",
+            "samples": 17980,
+            "min": 1,
+            "max": 1,
+            "sum": 17980,
+            "sumsquare": 17980
+          },
+          {
+            "name": "ost_create",
+            "units": "usec",
+            "samples": 578,
+            "min": 6,
+            "max": 2913,
+            "sum": 213507,
+            "sumsquare": 101752771
+          },
+          {
+            "name": "ost_destroy",
+            "units": "usec",
+            "samples": 15361,
+            "min": 45,
+            "max": 16367,
+            "sum": 8257699,
+            "sumsquare": 17357666429
+          },
+          {
+            "name": "ost_get_info",
+            "units": "usec",
+            "samples": 8,
+            "min": 645,
+            "max": 5798,
+            "sum": 14611,
+            "sumsquare": 58099255
+          },
+          {
+            "name": "ost_connect",
+            "units": "usec",
+            "samples": 68,
+            "min": 27,
+            "max": 151,
+            "sum": 4590,
+            "sumsquare": 346116
+          },
+          {
+            "name": "ost_disconnect",
+            "units": "usec",
+            "samples": 48,
+            "min": 28,
+            "max": 319,
+            "sum": 8078,
+            "sumsquare": 1610542
+          },
+          {
+            "name": "ost_sync",
+            "units": "usec",
+            "samples": 56,
+            "min": 5,
+            "max": 3754,
+            "sum": 17692,
+            "sumsquare": 30724000
+          },
+          {
+            "name": "ost_set_info",
+            "units": "usec",
+            "samples": 20,
+            "min": 10,
+            "max": 38,
+            "sum": 569,
+            "sumsquare": 17685
+          },
+          {
+            "name": "obd_ping",
+            "units": "usec",
+            "samples": 1050,
+            "min": 3,
+            "max": 47,
+            "sum": 17869,
+            "sumsquare": 352157
+          }
+        ]
       }
     }
   },
   {
     "Target": {
-      "ContendedLocks": {
-        "kind": "Ost",
-        "param": "contended_locks",
-        "target": "ai400x2-OST0000",
-        "value": 32
+      "Oss": {
+        "param": "ost_io",
+        "stats": [
+          {
+            "name": "req_waittime",
+            "units": "usec",
+            "samples": 26901856,
+            "min": 3,
+            "max": 30377,
+            "sum": 634484024,
+            "sumsquare": 67017160966
+          },
+          {
+            "name": "req_qdepth",
+            "units": "reqs",
+            "samples": 26901856,
+            "min": 0,
+            "max": 35,
+            "sum": 128008,
+            "sumsquare": 168296
+          },
+          {
+            "name": "req_active",
+            "units": "reqs",
+            "samples": 26901856,
+            "min": 1,
+            "max": 59,
+            "sum": 186318394,
+            "sumsquare": 2748893296
+          },
+          {
+            "name": "req_timeout",
+            "units": "sec",
+            "samples": 26901856,
+            "min": 15,
+            "max": 15,
+            "sum": 403527840,
+            "sumsquare": 6052917600
+          },
+          {
+            "name": "reqbuf_avail",
+            "units": "bufs",
+            "samples": 55114862,
+            "min": 63,
+            "max": 64,
+            "sum": 3526259632,
+            "sumsquare": 225611849680
+          },
+          {
+            "name": "ost_read",
+            "units": "usec",
+            "samples": 18668007,
+            "min": 26,
+            "max": 67617,
+            "sum": 17213363616,
+            "sumsquare": 35519190864978
+          },
+          {
+            "name": "ost_write",
+            "units": "usec",
+            "samples": 8233790,
+            "min": 57,
+            "max": 70720,
+            "sum": 12884209522,
+            "sumsquare": 60924472063584
+          },
+          {
+            "name": "ost_punch",
+            "units": "usec",
+            "samples": 59,
+            "min": 19,
+            "max": 705,
+            "sum": 3808,
+            "sumsquare": 1117930
+          }
+        ]
       }
     }
   },
   {
     "Target": {
-      "ContendedLocks": {
-        "kind": "Ost",
-        "param": "contended_locks",
-        "target": "ai400x2-OST0001",
-        "value": 32
+      "Oss": {
+        "param": "ost_create",
+        "stats": [
+          {
+            "name": "req_waittime",
+            "units": "usec",
+            "samples": 244994,
+            "min": 5,
+            "max": 47720,
+            "sum": 13993585,
+            "sumsquare": 87692498449
+          },
+          {
+            "name": "req_qdepth",
+            "units": "reqs",
+            "samples": 244994,
+            "min": 0,
+            "max": 1,
+            "sum": 105,
+            "sumsquare": 105
+          },
+          {
+            "name": "req_active",
+            "units": "reqs",
+            "samples": 244994,
+            "min": 1,
+            "max": 2,
+            "sum": 279479,
+            "sumsquare": 348449
+          },
+          {
+            "name": "req_timeout",
+            "units": "sec",
+            "samples": 244994,
+            "min": 1,
+            "max": 15,
+            "sum": 3673611,
+            "sumsquare": 55102641
+          },
+          {
+            "name": "reqbuf_avail",
+            "units": "bufs",
+            "samples": 507392,
+            "min": 63,
+            "max": 64,
+            "sum": 32463727,
+            "sumsquare": 2077088785
+          },
+          {
+            "name": "ost_statfs",
+            "units": "usec",
+            "samples": 244994,
+            "min": 4,
+            "max": 48630,
+            "sum": 7834717,
+            "sumsquare": 39139477245
+          }
+        ]
       }
     }
   },
   {
     "Target": {
-      "ContentionSeconds": {
-        "kind": "Mdt",
-        "param": "contention_seconds",
-        "target": "ai400x2-MDT0000",
-        "value": 2
+      "Oss": {
+        "param": "ost_out",
+        "stats": [
+          {
+            "name": "req_waittime",
+            "units": "usec",
+            "samples": 51413,
+            "min": 7,
+            "max": 16344,
+            "sum": 1985680,
+            "sumsquare": 2133648502
+          },
+          {
+            "name": "req_qdepth",
+            "units": "reqs",
+            "samples": 51413,
+            "min": 0,
+            "max": 0,
+            "sum": 0,
+            "sumsquare": 0
+          },
+          {
+            "name": "req_active",
+            "units": "reqs",
+            "samples": 51413,
+            "min": 1,
+            "max": 2,
+            "sum": 51416,
+            "sumsquare": 51422
+          },
+          {
+            "name": "req_timeout",
+            "units": "sec",
+            "samples": 51413,
+            "min": 1,
+            "max": 15,
+            "sum": 770432,
+            "sumsquare": 11555402
+          },
+          {
+            "name": "reqbuf_avail",
+            "units": "bufs",
+            "samples": 105488,
+            "min": 63,
+            "max": 64,
+            "sum": 6750253,
+            "sumsquare": 431954515
+          },
+          {
+            "name": "ldlm_ibits_enqueue",
+            "units": "reqs",
+            "samples": 26,
+            "min": 1,
+            "max": 1,
+            "sum": 26,
+            "sumsquare": 26
+          },
+          {
+            "name": "mds_connect",
+            "units": "usec",
+            "samples": 11,
+            "min": 49,
+            "max": 85,
+            "sum": 697,
+            "sumsquare": 45139
+          },
+          {
+            "name": "mds_statfs",
+            "units": "usec",
+            "samples": 51236,
+            "min": 5,
+            "max": 709,
+            "sum": 1406304,
+            "sumsquare": 42157834
+          },
+          {
+            "name": "obd_ping",
+            "units": "usec",
+            "samples": 6,
+            "min": 6,
+            "max": 17,
+            "sum": 68,
+            "sumsquare": 846
+          },
+          {
+            "name": "out_update",
+            "units": "usec",
+            "samples": 134,
+            "min": 6,
+            "max": 1557,
+            "sum": 11942,
+            "sumsquare": 8735808
+          }
+        ]
       }
     }
   },
   {
     "Target": {
-      "ContentionSeconds": {
-        "kind": "Ost",
-        "param": "contention_seconds",
-        "target": "ai400x2-OST0000",
-        "value": 2
-      }
-    }
-  },
-  {
-    "Target": {
-      "ContentionSeconds": {
-        "kind": "Ost",
-        "param": "contention_seconds",
-        "target": "ai400x2-OST0001",
-        "value": 2
-      }
-    }
-  },
-  {
-    "Target": {
-      "CtimeAgeLimit": {
-        "kind": "Mdt",
-        "param": "ctime_age_limit",
-        "target": "ai400x2-MDT0000",
-        "value": 10
-      }
-    }
-  },
-  {
-    "Target": {
-      "CtimeAgeLimit": {
-        "kind": "Ost",
-        "param": "ctime_age_limit",
-        "target": "ai400x2-OST0000",
-        "value": 10
-      }
-    }
-  },
-  {
-    "Target": {
-      "CtimeAgeLimit": {
-        "kind": "Ost",
-        "param": "ctime_age_limit",
-        "target": "ai400x2-OST0001",
-        "value": 10
-      }
-    }
-  },
-  {
-    "Target": {
-      "EarlyLockCancel": {
-        "kind": "Mdt",
-        "param": "early_lock_cancel",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "EarlyLockCancel": {
-        "kind": "Ost",
-        "param": "early_lock_cancel",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "EarlyLockCancel": {
-        "kind": "Ost",
-        "param": "early_lock_cancel",
-        "target": "ai400x2-OST0001",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockCount": {
-        "kind": "Mdt",
-        "param": "lock_count",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockCount": {
-        "kind": "Ost",
-        "param": "lock_count",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockCount": {
-        "kind": "Ost",
-        "param": "lock_count",
-        "target": "ai400x2-OST0001",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockTimeouts": {
-        "kind": "Mdt",
-        "param": "lock_timeouts",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockTimeouts": {
-        "kind": "Ost",
-        "param": "lock_timeouts",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockTimeouts": {
-        "kind": "Ost",
-        "param": "lock_timeouts",
-        "target": "ai400x2-OST0001",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockUnusedCount": {
-        "kind": "Mdt",
-        "param": "lock_unused_count",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockUnusedCount": {
-        "kind": "Ost",
-        "param": "lock_unused_count",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LockUnusedCount": {
-        "kind": "Ost",
-        "param": "lock_unused_count",
-        "target": "ai400x2-OST0001",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruMaxAge": {
-        "kind": "Mdt",
-        "param": "lru_max_age",
-        "target": "ai400x2-MDT0000",
-        "value": 3900000
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruMaxAge": {
-        "kind": "Ost",
-        "param": "lru_max_age",
-        "target": "ai400x2-OST0000",
-        "value": 3900000
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruMaxAge": {
-        "kind": "Ost",
-        "param": "lru_max_age",
-        "target": "ai400x2-OST0001",
-        "value": 3900000
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruSize": {
-        "kind": "Mdt",
-        "param": "lru_size",
-        "target": "ai400x2-MDT0000",
-        "value": 2000
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruSize": {
-        "kind": "Ost",
-        "param": "lru_size",
-        "target": "ai400x2-OST0000",
-        "value": 2000
-      }
-    }
-  },
-  {
-    "Target": {
-      "LruSize": {
-        "kind": "Ost",
-        "param": "lru_size",
-        "target": "ai400x2-OST0001",
-        "value": 2000
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxNolockBytes": {
-        "kind": "Mdt",
-        "param": "max_nolock_bytes",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxNolockBytes": {
-        "kind": "Ost",
-        "param": "max_nolock_bytes",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxNolockBytes": {
-        "kind": "Ost",
-        "param": "max_nolock_bytes",
-        "target": "ai400x2-OST0001",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxParallelAst": {
-        "kind": "Mdt",
-        "param": "max_parallel_ast",
-        "target": "ai400x2-MDT0000",
-        "value": 1024
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxParallelAst": {
-        "kind": "Ost",
-        "param": "max_parallel_ast",
-        "target": "ai400x2-OST0000",
-        "value": 1024
-      }
-    }
-  },
-  {
-    "Target": {
-      "MaxParallelAst": {
-        "kind": "Ost",
-        "param": "max_parallel_ast",
-        "target": "ai400x2-OST0001",
-        "value": 1024
-      }
-    }
-  },
-  {
-    "Target": {
-      "ResourceCount": {
-        "kind": "Mdt",
-        "param": "resource_count",
-        "target": "ai400x2-MDT0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "ResourceCount": {
-        "kind": "Ost",
-        "param": "resource_count",
-        "target": "ai400x2-OST0000",
-        "value": 0
-      }
-    }
-  },
-  {
-    "Target": {
-      "ResourceCount": {
-        "kind": "Ost",
-        "param": "resource_count",
-        "target": "ai400x2-OST0001",
-        "value": 0
+      "Oss": {
+        "param": "ost_seq",
+        "stats": [
+          {
+            "name": "req_waittime",
+            "units": "usec",
+            "samples": 30,
+            "min": 15,
+            "max": 563,
+            "sum": 1776,
+            "sumsquare": 381252
+          },
+          {
+            "name": "req_qdepth",
+            "units": "reqs",
+            "samples": 30,
+            "min": 0,
+            "max": 0,
+            "sum": 0,
+            "sumsquare": 0
+          },
+          {
+            "name": "req_active",
+            "units": "reqs",
+            "samples": 30,
+            "min": 1,
+            "max": 2,
+            "sum": 32,
+            "sumsquare": 36
+          },
+          {
+            "name": "req_timeout",
+            "units": "sec",
+            "samples": 30,
+            "min": 1,
+            "max": 10,
+            "sum": 75,
+            "sumsquare": 525
+          },
+          {
+            "name": "reqbuf_avail",
+            "units": "bufs",
+            "samples": 79,
+            "min": 64,
+            "max": 64,
+            "sum": 5056,
+            "sumsquare": 323584
+          },
+          {
+            "name": "seq_query",
+            "units": "usec",
+            "samples": 30,
+            "min": 3,
+            "max": 5309,
+            "sum": 28881,
+            "sumsquare": 134979703
+          }
+        ]
       }
     }
   },
@@ -1454,83 +2386,101 @@
           {
             "name": "open",
             "units": "usecs",
-            "samples": 10,
-            "min": 55,
-            "max": 1160,
-            "sum": 2312,
-            "sumsquare": 1529624
+            "samples": 232,
+            "min": 24,
+            "max": 1091,
+            "sum": 22203,
+            "sumsquare": 3836069
           },
           {
             "name": "close",
             "units": "usecs",
-            "samples": 90,
+            "samples": 7632,
             "min": 7,
-            "max": 90,
-            "sum": 1926,
-            "sumsquare": 77484
+            "max": 255,
+            "sum": 191804,
+            "sumsquare": 6447596
           },
           {
             "name": "mknod",
             "units": "usecs",
-            "samples": 7,
-            "min": 69,
-            "max": 1138,
-            "sum": 2038,
-            "sumsquare": 1448670
+            "samples": 228,
+            "min": 47,
+            "max": 1081,
+            "sum": 19926,
+            "sumsquare": 3382060
           },
           {
             "name": "unlink",
             "units": "usecs",
-            "samples": 4,
-            "min": 58,
-            "max": 163,
-            "sum": 466,
-            "sumsquare": 60366
+            "samples": 3,
+            "min": 412,
+            "max": 4498,
+            "sum": 5408,
+            "sumsquare": 20649752
           },
           {
             "name": "mkdir",
             "units": "usecs",
-            "samples": 1,
-            "min": 5054,
-            "max": 5054,
-            "sum": 5054,
-            "sumsquare": 25542916
+            "samples": 6,
+            "min": 162,
+            "max": 2911,
+            "sum": 5639,
+            "sumsquare": 10578071
+          },
+          {
+            "name": "rmdir",
+            "units": "usecs",
+            "samples": 4,
+            "min": 58,
+            "max": 115,
+            "sum": 302,
+            "sumsquare": 24994
           },
           {
             "name": "getattr",
             "units": "usecs",
-            "samples": 37,
-            "min": 2,
-            "max": 97,
-            "sum": 787,
-            "sumsquare": 35117
+            "samples": 9464,
+            "min": 0,
+            "max": 1740,
+            "sum": 44670,
+            "sumsquare": 5861688
           },
           {
             "name": "setattr",
             "units": "usecs",
-            "samples": 10,
-            "min": 34,
-            "max": 89,
-            "sum": 528,
-            "sumsquare": 30090
+            "samples": 228,
+            "min": 18,
+            "max": 241,
+            "sum": 8279,
+            "sumsquare": 363795
           },
           {
             "name": "getxattr",
             "units": "usecs",
-            "samples": 2,
-            "min": 13,
-            "max": 17,
-            "sum": 30,
-            "sumsquare": 458
+            "samples": 3591,
+            "min": 6,
+            "max": 47,
+            "sum": 50689,
+            "sumsquare": 765417
           },
           {
             "name": "statfs",
             "units": "usecs",
-            "samples": 773897,
+            "samples": 91893,
             "min": 0,
-            "max": 104,
-            "sum": 5981127,
-            "sumsquare": 53619709
+            "max": 65,
+            "sum": 634431,
+            "sumsquare": 5333055
+          },
+          {
+            "name": "sync",
+            "units": "usecs",
+            "samples": 224,
+            "min": 2,
+            "max": 24,
+            "sum": 1433,
+            "sumsquare": 11323
           }
         ]
       }
@@ -1542,8 +2492,488 @@
         "kind": "Mdt",
         "param": "num_exports",
         "target": "ai400x2-MDT0000",
-        "value": 19
+        "value": 16
       }
+    }
+  },
+  {
+    "Target": {
+      "ContendedLocks": {
+        "kind": "Mdt",
+        "param": "contended_locks",
+        "target": "ai400x2-MDT0000",
+        "value": 32
+      }
+    }
+  },
+  {
+    "Target": {
+      "ContendedLocks": {
+        "kind": "Ost",
+        "param": "contended_locks",
+        "target": "ai400x2-OST0000",
+        "value": 32
+      }
+    }
+  },
+  {
+    "Target": {
+      "ContendedLocks": {
+        "kind": "Ost",
+        "param": "contended_locks",
+        "target": "ai400x2-OST0001",
+        "value": 32
+      }
+    }
+  },
+  {
+    "Target": {
+      "ContentionSeconds": {
+        "kind": "Mdt",
+        "param": "contention_seconds",
+        "target": "ai400x2-MDT0000",
+        "value": 2
+      }
+    }
+  },
+  {
+    "Target": {
+      "ContentionSeconds": {
+        "kind": "Ost",
+        "param": "contention_seconds",
+        "target": "ai400x2-OST0000",
+        "value": 2
+      }
+    }
+  },
+  {
+    "Target": {
+      "ContentionSeconds": {
+        "kind": "Ost",
+        "param": "contention_seconds",
+        "target": "ai400x2-OST0001",
+        "value": 2
+      }
+    }
+  },
+  {
+    "Target": {
+      "CtimeAgeLimit": {
+        "kind": "Mdt",
+        "param": "ctime_age_limit",
+        "target": "ai400x2-MDT0000",
+        "value": 10
+      }
+    }
+  },
+  {
+    "Target": {
+      "CtimeAgeLimit": {
+        "kind": "Ost",
+        "param": "ctime_age_limit",
+        "target": "ai400x2-OST0000",
+        "value": 10
+      }
+    }
+  },
+  {
+    "Target": {
+      "CtimeAgeLimit": {
+        "kind": "Ost",
+        "param": "ctime_age_limit",
+        "target": "ai400x2-OST0001",
+        "value": 10
+      }
+    }
+  },
+  {
+    "Target": {
+      "EarlyLockCancel": {
+        "kind": "Mdt",
+        "param": "early_lock_cancel",
+        "target": "ai400x2-MDT0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "EarlyLockCancel": {
+        "kind": "Ost",
+        "param": "early_lock_cancel",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "EarlyLockCancel": {
+        "kind": "Ost",
+        "param": "early_lock_cancel",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockCount": {
+        "kind": "Mdt",
+        "param": "lock_count",
+        "target": "ai400x2-MDT0000",
+        "value": 2
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockCount": {
+        "kind": "Ost",
+        "param": "lock_count",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockCount": {
+        "kind": "Ost",
+        "param": "lock_count",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockTimeouts": {
+        "kind": "Mdt",
+        "param": "lock_timeouts",
+        "target": "ai400x2-MDT0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockTimeouts": {
+        "kind": "Ost",
+        "param": "lock_timeouts",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockTimeouts": {
+        "kind": "Ost",
+        "param": "lock_timeouts",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockUnusedCount": {
+        "kind": "Mdt",
+        "param": "lock_unused_count",
+        "target": "ai400x2-MDT0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockUnusedCount": {
+        "kind": "Ost",
+        "param": "lock_unused_count",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LockUnusedCount": {
+        "kind": "Ost",
+        "param": "lock_unused_count",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruMaxAge": {
+        "kind": "Mdt",
+        "param": "lru_max_age",
+        "target": "ai400x2-MDT0000",
+        "value": 3900000
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruMaxAge": {
+        "kind": "Ost",
+        "param": "lru_max_age",
+        "target": "ai400x2-OST0000",
+        "value": 3900000
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruMaxAge": {
+        "kind": "Ost",
+        "param": "lru_max_age",
+        "target": "ai400x2-OST0001",
+        "value": 3900000
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruSize": {
+        "kind": "Mdt",
+        "param": "lru_size",
+        "target": "ai400x2-MDT0000",
+        "value": 2400
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruSize": {
+        "kind": "Ost",
+        "param": "lru_size",
+        "target": "ai400x2-OST0000",
+        "value": 2400
+      }
+    }
+  },
+  {
+    "Target": {
+      "LruSize": {
+        "kind": "Ost",
+        "param": "lru_size",
+        "target": "ai400x2-OST0001",
+        "value": 2400
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxNolockBytes": {
+        "kind": "Mdt",
+        "param": "max_nolock_bytes",
+        "target": "ai400x2-MDT0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxNolockBytes": {
+        "kind": "Ost",
+        "param": "max_nolock_bytes",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxNolockBytes": {
+        "kind": "Ost",
+        "param": "max_nolock_bytes",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxParallelAst": {
+        "kind": "Mdt",
+        "param": "max_parallel_ast",
+        "target": "ai400x2-MDT0000",
+        "value": 1024
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxParallelAst": {
+        "kind": "Ost",
+        "param": "max_parallel_ast",
+        "target": "ai400x2-OST0000",
+        "value": 1024
+      }
+    }
+  },
+  {
+    "Target": {
+      "MaxParallelAst": {
+        "kind": "Ost",
+        "param": "max_parallel_ast",
+        "target": "ai400x2-OST0001",
+        "value": 1024
+      }
+    }
+  },
+  {
+    "Target": {
+      "ResourceCount": {
+        "kind": "Mdt",
+        "param": "resource_count",
+        "target": "ai400x2-MDT0000",
+        "value": 1
+      }
+    }
+  },
+  {
+    "Target": {
+      "ResourceCount": {
+        "kind": "Ost",
+        "param": "resource_count",
+        "target": "ai400x2-OST0000",
+        "value": 0
+      }
+    }
+  },
+  {
+    "Target": {
+      "ResourceCount": {
+        "kind": "Ost",
+        "param": "resource_count",
+        "target": "ai400x2-OST0001",
+        "value": 0
+      }
+    }
+  },
+  {
+    "LustreService": {
+      "LdlmCanceld": [
+        {
+          "name": "req_waittime",
+          "units": "usec",
+          "samples": 30049,
+          "min": 3,
+          "max": 7981,
+          "sum": 755915,
+          "sumsquare": 287075573
+        },
+        {
+          "name": "req_qdepth",
+          "units": "reqs",
+          "samples": 30049,
+          "min": 0,
+          "max": 3,
+          "sum": 125,
+          "sumsquare": 159
+        },
+        {
+          "name": "req_active",
+          "units": "reqs",
+          "samples": 30049,
+          "min": 1,
+          "max": 4,
+          "sum": 35199,
+          "sumsquare": 48323
+        },
+        {
+          "name": "req_timeout",
+          "units": "sec",
+          "samples": 30049,
+          "min": 1,
+          "max": 15,
+          "sum": 450182,
+          "sumsquare": 6751862
+        },
+        {
+          "name": "reqbuf_avail",
+          "units": "bufs",
+          "samples": 61601,
+          "min": 60,
+          "max": 64,
+          "sum": 3929009,
+          "sumsquare": 250609501
+        },
+        {
+          "name": "ldlm_cancel",
+          "units": "usec",
+          "samples": 30049,
+          "min": 3,
+          "max": 13824,
+          "sum": 2293482,
+          "sumsquare": 1623673342
+        }
+      ]
+    }
+  },
+  {
+    "LustreService": {
+      "LdlmCbd": [
+        {
+          "name": "req_waittime",
+          "units": "usec",
+          "samples": 79,
+          "min": 11,
+          "max": 106,
+          "sum": 3906,
+          "sumsquare": 229000
+        },
+        {
+          "name": "req_qdepth",
+          "units": "reqs",
+          "samples": 79,
+          "min": 0,
+          "max": 1,
+          "sum": 3,
+          "sumsquare": 3
+        },
+        {
+          "name": "req_active",
+          "units": "reqs",
+          "samples": 79,
+          "min": 1,
+          "max": 3,
+          "sum": 117,
+          "sumsquare": 213
+        },
+        {
+          "name": "req_timeout",
+          "units": "sec",
+          "samples": 79,
+          "min": 1,
+          "max": 15,
+          "sum": 1049,
+          "sumsquare": 15509
+        },
+        {
+          "name": "reqbuf_avail",
+          "units": "bufs",
+          "samples": 177,
+          "min": 0,
+          "max": 1,
+          "sum": 163,
+          "sumsquare": 163
+        },
+        {
+          "name": "ldlm_bl_callback",
+          "units": "usec",
+          "samples": 79,
+          "min": 4,
+          "max": 42,
+          "sum": 1378,
+          "sumsquare": 29612
+        }
+      ]
     }
   },
   {
@@ -1551,7 +2981,7 @@
       "SendCount": {
         "nid": "0@lo",
         "param": "send_count",
-        "value": 3647005
+        "value": 191882
       }
     }
   },
@@ -1560,7 +2990,7 @@
       "RecvCount": {
         "nid": "0@lo",
         "param": "recv_count",
-        "value": 3646880
+        "value": 191882
       }
     }
   },
@@ -1569,61 +2999,61 @@
       "DropCount": {
         "nid": "0@lo",
         "param": "drop_count",
-        "value": 125
+        "value": 0
       }
     }
   },
   {
     "LNetStat": {
       "SendCount": {
-        "nid": "172.16.0.24@o2ib",
+        "nid": "172.16.240.133@o2ib",
         "param": "send_count",
-        "value": 12450030
+        "value": 28893723
       }
     }
   },
   {
     "LNetStat": {
       "RecvCount": {
-        "nid": "172.16.0.24@o2ib",
+        "nid": "172.16.240.133@o2ib",
         "param": "recv_count",
-        "value": 12463326
+        "value": 24143352
       }
     }
   },
   {
     "LNetStat": {
       "DropCount": {
-        "nid": "172.16.0.24@o2ib",
+        "nid": "172.16.240.133@o2ib",
         "param": "drop_count",
-        "value": 57
+        "value": 0
       }
     }
   },
   {
     "LNetStat": {
       "SendCount": {
-        "nid": "172.16.0.28@o2ib",
+        "nid": "172.16.241.133@o2ib",
         "param": "send_count",
-        "value": 12448709
+        "value": 28892480
       }
     }
   },
   {
     "LNetStat": {
       "RecvCount": {
-        "nid": "172.16.0.28@o2ib",
+        "nid": "172.16.241.133@o2ib",
         "param": "recv_count",
-        "value": 12462034
+        "value": 24141806
       }
     }
   },
   {
     "LNetStat": {
       "DropCount": {
-        "nid": "172.16.0.28@o2ib",
+        "nid": "172.16.241.133@o2ib",
         "param": "drop_count",
-        "value": 69
+        "value": 0
       }
     }
   },
@@ -1633,7 +3063,9 @@
         "kind": "Mgt",
         "param": "fsnames",
         "target": "MGS",
-        "value": ["ai400x2"]
+        "value": [
+          "ai400x2"
+        ]
       }
     }
   },
@@ -1643,7 +3075,7 @@
         "kind": "Ost",
         "param": "recovery_status",
         "target": "ai400x2-OST0000",
-        "value": "Complete"
+        "value": "Inactive"
       }
     }
   },
@@ -1653,7 +3085,7 @@
         "kind": "Ost",
         "param": "recovery_status",
         "target": "ai400x2-OST0001",
-        "value": "Complete"
+        "value": "Inactive"
       }
     }
   },
@@ -1663,7 +3095,31 @@
         "kind": "Mdt",
         "param": "recovery_status",
         "target": "ai400x2-MDT0000",
-        "value": "Complete"
+        "value": "Inactive"
+      }
+    }
+  },
+  {
+    "LNetStat": {
+      "SendLength": {
+        "param": "send_length",
+        "value": 21225620772816
+      }
+    }
+  },
+  {
+    "LNetStat": {
+      "RecvLength": {
+        "param": "recv_length",
+        "value": 9966973976959
+      }
+    }
+  },
+  {
+    "LNetStat": {
+      "DropLength": {
+        "param": "drop_length",
+        "value": 0
       }
     }
   }

--- a/src/snapshots/lustrefs_exporter__tests__stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__stats.snap
@@ -4,81 +4,337 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 1918767104 0
-lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 142034284544 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 3334853013504 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 3335272443904 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 1873772 0
+lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 419917436 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 34187914484 0
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 34188706564 0
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 2027556864 0
-lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 144541634560 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 3544070828032 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 3544070828032 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036 0
+lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427170984 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 34750424936 0
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 34750424936 0
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 4 0
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 4 0
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1 0
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1 0
 
 # HELP lustre_dio_frags Current disk IO fragmentation for the given size.
 # TYPE lustre_dio_frags gauge
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 2 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9292607 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 4076945 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 3669 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 3434 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 2 0
 lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 736 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 625 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 11 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 2509 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 6 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 2041 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 55768 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 38711 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9254837 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 4080923 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 3808 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 3599 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 14 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 2603 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 7 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 2055 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 0 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 57294 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 39039 0
 
 # HELP lustre_discontiguous_blocks_total 
 # TYPE lustre_discontiguous_blocks_total counter
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 738 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 625 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9292664 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4072612 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 42047 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 28493 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 17352 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 21665 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 687 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 137 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 27 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 13 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 5 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 1 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9254895 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4076814 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 41231 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 28934 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 19835 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 21641 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 635 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 146 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 33 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 12 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 3 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 0 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 1 0
 
 # HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
 # TYPE lustre_discontiguous_pages_total counter
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 738 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 625 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9351652 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4114231 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 409 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 9407 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 2 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 2 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9315526 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4118794 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 435 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 9423 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 2 0
 
 # HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
 # TYPE lustre_disk_io gauge
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 738 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 736 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 736 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 736 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 625 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 625 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 625 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 625 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 2499387 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 1187036 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 1883945 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 793707 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 1493683 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 503920 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 1058167 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 395381 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 704804 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 288275 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 495027 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 197769 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 356780 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 132864 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 256413 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 89052 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="9"} 181632 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="9"} 58501 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="10"} 123818 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="10"} 26704 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="11"} 90035 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="11"} 14119 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="12"} 68887 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="12"} 8829 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="13"} 55465 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="13"} 6550 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="14"} 45232 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="14"} 5547 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="15"} 38000 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="15"} 5383 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 31971 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 5481 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="17"} 25211 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="17"} 6177 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="18"} 21467 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="18"} 6767 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="19"} 18780 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="19"} 8074 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="20"} 16625 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="20"} 9646 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="21"} 15098 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="21"} 12313 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="22"} 13849 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="22"} 15267 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="23"} 13017 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="23"} 19877 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="24"} 12337 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="24"} 24453 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="25"} 11413 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="25"} 30315 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="26"} 11028 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="26"} 34324 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="27"} 10704 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="27"} 37750 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="28"} 10471 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="28"} 38776 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="29"} 10297 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="29"} 38871 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="30"} 10119 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="30"} 36556 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="31"} 162513 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="31"} 377499 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 2488039 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 1185285 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 1873744 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 787309 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1490244 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 498673 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 1058749 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 395423 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 704439 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 291932 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 495012 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 201902 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 357583 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 137081 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 255910 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 91340 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 181672 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 59739 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 122401 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 27549 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 88149 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 14513 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 67154 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 9077 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 53823 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 6688 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 44023 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 5725 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 37170 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 5530 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 31368 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 5664 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 24929 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 6440 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 21347 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 7087 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 18674 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 8465 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 16527 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 10044 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 15156 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 12647 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 14051 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 15863 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 13243 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 20105 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 12577 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 24737 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 11661 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 30564 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 11371 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 34765 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 11019 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 37755 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 10843 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 38708 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 10656 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 38610 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 10512 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 36144 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 168860 0
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 377811 0
 
 # HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
 # TYPE lustre_disk_io_total counter
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 2946 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 2500 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 48747 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 9253 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="8192"} 808 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="8192"} 24 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="16384"} 342 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="16384"} 144 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="32768"} 819 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="32768"} 129 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="65536"} 1394 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="65536"} 344 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="131072"} 3731 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="131072"} 777 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="262144"} 5397 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="262144"} 1152 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="524288"} 8031 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="524288"} 1759 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 9230582 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 4063409 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="2097152"} 446324 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="2097152"} 338792 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 50197 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 9280 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="8192"} 710 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="8192"} 28 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="16384"} 281 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="16384"} 125 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="32768"} 867 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="32768"} 148 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="65536"} 1407 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="65536"} 329 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="131072"} 3430 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="131072"} 741 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="262144"} 5639 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="262144"} 1216 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="524288"} 7966 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="524288"} 1763 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 9191867 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 4067353 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="2097152"} 458542 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="2097152"} 342192 0
+
+# HELP lustre_drop_bytes_total Total number of bytes that have been dropped
+# TYPE lustre_drop_bytes_total counter
+lustre_drop_bytes_total 0 0
 
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
-lustre_drop_count_total{nid="0@lo"} 125 0
-lustre_drop_count_total{nid="172.16.0.24@o2ib"} 57 0
-lustre_drop_count_total{nid="172.16.0.28@o2ib"} 69 0
+lustre_drop_count_total{nid="0@lo"} 0 0
+lustre_drop_count_total{nid="172.16.240.133@o2ib"} 0 0
+lustre_drop_count_total{nid="172.16.241.133@o2ib"} 0 0
 
 # HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
 # TYPE lustre_exports_dirty_total counter
@@ -87,8 +343,8 @@ lustre_exports_dirty_total{component="ost",target="ai400x2-OST0001"} 0 0
 
 # HELP lustre_exports_granted_total Total number of exports that have been marked granted
 # TYPE lustre_exports_granted_total counter
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 276416 0
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 276416 0
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 143424 0
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 143424 0
 
 # HELP lustre_exports_pending_total Total number of exports that have been marked pending
 # TYPE lustre_exports_pending_total counter
@@ -97,52 +353,82 @@ lustre_exports_pending_total{component="ost",target="ai400x2-OST0001"} 0 0
 
 # HELP lustre_exports_total Total number of times the pool has been exported
 # TYPE lustre_exports_total counter
-lustre_exports_total{component="mgt",target="MGS"} 4 0
+lustre_exports_total{component="mgt",target="MGS"} 6 0
 lustre_exports_total{component="ost",target="ai400x2-OST0000"} 4 0
 lustre_exports_total{component="ost",target="ai400x2-OST0001"} 4 0
-lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 19 0
+lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 16 0
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 2026139648 0
-lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 144535597056 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 3541028220928 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 3541447651328 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 1978628 0
+lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427164896 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 34539581312 0
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 34540373392 0
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge
 lustre_inodes_free{component="mgt",target="MGS"} 130871 0
-lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 97713887 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 1073740846 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 1073740847 0
+lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 289887431 0
+lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 274725135 0
+lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 274725134 0
 
 # HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
 # TYPE lustre_inodes_maximum gauge
 lustre_inodes_maximum{component="mgt",target="MGS"} 131072 0
-lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 97714176 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 1073741824 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 1073741824 0
+lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 289887952 0
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 274726912 0
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 274726912 0
 
 # HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
 # TYPE lustre_io_time_milliseconds_total counter
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 734 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 3 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 1 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 621 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 1 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 3 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9244557 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 3616861 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 45925 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 83848 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 30611 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 314948 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 26141 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 49922 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 4808 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 51585 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 14 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 6394 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 6 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 82 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 1 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 0 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9207507 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 3621675 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 45907 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 83387 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 31151 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 314557 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 26619 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 50234 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 4762 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 52033 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 9 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 6238 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 6 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 95 0
+
+# HELP lustre_ldlm_canceld_stats Gives information about LDLM Canceld service.
+# TYPE lustre_ldlm_canceld_stats counter
+lustre_ldlm_canceld_stats{operation="req_waittime"} 30049 0
+lustre_ldlm_canceld_stats{operation="req_qdepth"} 30049 0
+lustre_ldlm_canceld_stats{operation="req_active"} 30049 0
+lustre_ldlm_canceld_stats{operation="req_timeout"} 30049 0
+lustre_ldlm_canceld_stats{operation="reqbuf_avail"} 61601 0
+lustre_ldlm_canceld_stats{operation="ldlm_cancel"} 30049 0
+
+# HELP lustre_ldlm_cbd_stats Gives information about LDLM Callback service.
+# TYPE lustre_ldlm_cbd_stats counter
+lustre_ldlm_cbd_stats{operation="req_waittime"} 79 0
+lustre_ldlm_cbd_stats{operation="req_qdepth"} 79 0
+lustre_ldlm_cbd_stats{operation="req_active"} 79 0
+lustre_ldlm_cbd_stats{operation="req_timeout"} 79 0
+lustre_ldlm_cbd_stats{operation="reqbuf_avail"} 177 0
+lustre_ldlm_cbd_stats{operation="ldlm_bl_callback"} 79 0
 
 # HELP lustre_lock_contended_total Number of contended locks
 # TYPE lustre_lock_contended_total counter
@@ -158,7 +444,7 @@ lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0001"} 2
 
 # HELP lustre_lock_count_total Number of locks
 # TYPE lustre_lock_count_total counter
-lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 0 0
+lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 2 0
 lustre_lock_count_total{component="ost",target="ai400x2-OST0000"} 0 0
 lustre_lock_count_total{component="ost",target="ai400x2-OST0001"} 0 0
 
@@ -168,58 +454,170 @@ lustre_lock_timeout_total{component="mdt",target="ai400x2-MDT0000"} 0 0
 lustre_lock_timeout_total{component="ost",target="ai400x2-OST0000"} 0 0
 lustre_lock_timeout_total{component="ost",target="ai400x2-OST0001"} 0 0
 
+# HELP lustre_oss_ost_create_stats OSS ost_create stats
+# TYPE lustre_oss_ost_create_stats gauge
+lustre_oss_ost_create_stats{operation="req_waittime",units="usec"} 244994 0
+lustre_oss_ost_create_stats{operation="req_qdepth",units="reqs"} 244994 0
+lustre_oss_ost_create_stats{operation="req_active",units="reqs"} 244994 0
+lustre_oss_ost_create_stats{operation="req_timeout",units="sec"} 244994 0
+lustre_oss_ost_create_stats{operation="reqbuf_avail",units="bufs"} 507392 0
+lustre_oss_ost_create_stats{operation="ost_statfs",units="usec"} 244994 0
+
+# HELP lustre_oss_ost_io_stats OSS ost_io stats
+# TYPE lustre_oss_ost_io_stats gauge
+lustre_oss_ost_io_stats{operation="req_waittime",units="usec"} 26901856 0
+lustre_oss_ost_io_stats{operation="req_qdepth",units="reqs"} 26901856 0
+lustre_oss_ost_io_stats{operation="req_active",units="reqs"} 26901856 0
+lustre_oss_ost_io_stats{operation="req_timeout",units="sec"} 26901856 0
+lustre_oss_ost_io_stats{operation="reqbuf_avail",units="bufs"} 55114862 0
+lustre_oss_ost_io_stats{operation="ost_read",units="usec"} 18668007 0
+lustre_oss_ost_io_stats{operation="ost_write",units="usec"} 8233790 0
+lustre_oss_ost_io_stats{operation="ost_punch",units="usec"} 59 0
+
+# HELP lustre_oss_ost_stats OSS ost stats
+# TYPE lustre_oss_ost_stats gauge
+lustre_oss_ost_stats{operation="req_waittime",units="usec"} 77655 0
+lustre_oss_ost_stats{operation="req_qdepth",units="reqs"} 77655 0
+lustre_oss_ost_stats{operation="req_active",units="reqs"} 77655 0
+lustre_oss_ost_stats{operation="req_timeout",units="sec"} 77655 0
+lustre_oss_ost_stats{operation="reqbuf_avail",units="bufs"} 157527 0
+lustre_oss_ost_stats{operation="ldlm_glimpse_enqueue",units="reqs"} 42486 0
+lustre_oss_ost_stats{operation="ldlm_extent_enqueue",units="reqs"} 17980 0
+lustre_oss_ost_stats{operation="ost_create",units="usec"} 578 0
+lustre_oss_ost_stats{operation="ost_destroy",units="usec"} 15361 0
+lustre_oss_ost_stats{operation="ost_get_info",units="usec"} 8 0
+lustre_oss_ost_stats{operation="ost_connect",units="usec"} 68 0
+lustre_oss_ost_stats{operation="ost_disconnect",units="usec"} 48 0
+lustre_oss_ost_stats{operation="ost_sync",units="usec"} 56 0
+lustre_oss_ost_stats{operation="ost_set_info",units="usec"} 20 0
+lustre_oss_ost_stats{operation="obd_ping",units="usec"} 1050 0
+
 # HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
 # TYPE lustre_pages_per_bulk_rw_total counter
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 2 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 45221 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 192 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 807 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 67 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 341 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 262 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 818 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 262 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 1382 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 728 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 3718 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 1548 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 5363 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 2295 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 7996 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 3506 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 9230582 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 4068108 0
 lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="512"} 0 0
 lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1024"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1024"} 736 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1024"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1024"} 625 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1024"} 50 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1024"} 3411 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2048"} 11 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2048"} 2509 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 55774 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 40752 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 46495 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 208 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 709 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 85 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 281 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 248 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 867 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 281 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 1396 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 702 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 3421 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 1478 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 5613 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 2418 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 7951 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 3519 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 9191867 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 4072014 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="512"} 0 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1024"} 46 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1024"} 3569 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2048"} 14 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2048"} 2603 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 57301 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 41094 0
+
+# HELP lustre_read_bytes_total The total number of bytes that have been read.
+# TYPE lustre_read_bytes_total counter
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0000"} 10614117224448 0
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0001"} 10599265554432 0
+
+# HELP lustre_read_maximum_size_bytes The maximum read size in bytes.
+# TYPE lustre_read_maximum_size_bytes gauge
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 16777216 0
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 16777216 0
+
+# HELP lustre_read_minimum_size_bytes The minimum read size in bytes.
+# TYPE lustre_read_minimum_size_bytes gauge
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 4096 0
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 4096 0
+
+# HELP lustre_read_samples_total Total number of reads that have been recorded.
+# TYPE lustre_read_samples_total counter
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 9352060 0
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0001"} 9315947 0
+
+# HELP lustre_receive_bytes_total Total number of bytes that have been received
+# TYPE lustre_receive_bytes_total counter
+lustre_receive_bytes_total 9966973976959 0
 
 # HELP lustre_receive_count_total Total number of messages that have been received
 # TYPE lustre_receive_count_total counter
-lustre_receive_count_total{nid="0@lo"} 3646880 0
-lustre_receive_count_total{nid="172.16.0.24@o2ib"} 12463326 0
-lustre_receive_count_total{nid="172.16.0.28@o2ib"} 12462034 0
+lustre_receive_count_total{nid="0@lo"} 191882 0
+lustre_receive_count_total{nid="172.16.240.133@o2ib"} 24143352 0
+lustre_receive_count_total{nid="172.16.241.133@o2ib"} 24141806 0
+
+# HELP lustre_send_bytes_total Total number of bytes that have been sent
+# TYPE lustre_send_bytes_total counter
+lustre_send_bytes_total 21225620772816 0
 
 # HELP lustre_send_count_total Total number of messages that have been sent
 # TYPE lustre_send_count_total counter
-lustre_send_count_total{nid="0@lo"} 3647005 0
-lustre_send_count_total{nid="172.16.0.24@o2ib"} 12450030 0
-lustre_send_count_total{nid="172.16.0.28@o2ib"} 12448709 0
+lustre_send_count_total{nid="0@lo"} 191882 0
+lustre_send_count_total{nid="172.16.240.133@o2ib"} 28893723 0
+lustre_send_count_total{nid="172.16.241.133@o2ib"} 28892480 0
 
 # HELP lustre_stats_total Number of operations the filesystem has performed.
 # TYPE lustre_stats_total counter
-lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 10 0
-lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 90 0
-lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 7 0
-lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 4 0
-lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 1 0
-lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 37 0
-lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 10 0
-lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 2 0
-lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 773897 0
+lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 232 0
+lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 7632 0
+lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 228 0
+lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 3 0
+lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 6 0
+lustre_stats_total{component="mdt",operation="rmdir",target="ai400x2-MDT0000"} 4 0
+lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 9464 0
+lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 228 0
+lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 3591 0
+lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 91893 0
+lustre_stats_total{component="mdt",operation="sync",target="ai400x2-MDT0000"} 224 0
 
 # HELP lustre_write_bytes_total The total number of bytes that have been written.
 # TYPE lustre_write_bytes_total counter
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 3089104896 0
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 2621440000 0
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 4971114377425 0
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 4982409908141 0
 
 # HELP lustre_write_maximum_size_bytes The maximum write size in bytes.
 # TYPE lustre_write_maximum_size_bytes gauge
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 4194304 0
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 4194304 0
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 16777216 0
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 16777216 0
 
 # HELP lustre_write_minimum_size_bytes The minimum write size in bytes.
 # TYPE lustre_write_minimum_size_bytes gauge
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 1048576 0
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 4194304 0
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 183 0
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 183 0
 
 # HELP lustre_write_samples_total Total number of writes that have been recorded.
 # TYPE lustre_write_samples_total counter
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 738 0
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 625 0
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 4114603 0
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 4119187 0
 


### PR DESCRIPTION
Fix EX-7933

```
# HELP lustre_oss_ost_create_stats OSS ost_create stats
# TYPE lustre_oss_ost_create_stats gauge
lustre_oss_ost_create_stats{operation="req_waittime",units="usec"} 246338 1689840634153
lustre_oss_ost_create_stats{operation="req_qdepth",units="reqs"} 246338 1689840634153
lustre_oss_ost_create_stats{operation="req_active",units="reqs"} 246338 1689840634153
lustre_oss_ost_create_stats{operation="req_timeout",units="sec"} 246338 1689840634153
lustre_oss_ost_create_stats{operation="reqbuf_avail",units="bufs"} 510150 1689840634153
lustre_oss_ost_create_stats{operation="ost_statfs",units="usec"} 246338 1689840634153

# HELP lustre_oss_ost_io_stats OSS ost_io stats
# TYPE lustre_oss_ost_io_stats gauge
lustre_oss_ost_io_stats{operation="req_waittime",units="usec"} 26901856 1689840634153
lustre_oss_ost_io_stats{operation="req_qdepth",units="reqs"} 26901856 1689840634153
lustre_oss_ost_io_stats{operation="req_active",units="reqs"} 26901856 1689840634153
lustre_oss_ost_io_stats{operation="req_timeout",units="sec"} 26901856 1689840634153
lustre_oss_ost_io_stats{operation="reqbuf_avail",units="bufs"} 55114862 1689840634153
lustre_oss_ost_io_stats{operation="ost_read",units="usec"} 18668007 1689840634153
lustre_oss_ost_io_stats{operation="ost_write",units="usec"} 8233790 1689840634153
lustre_oss_ost_io_stats{operation="ost_punch",units="usec"} 59 1689840634153

# HELP lustre_oss_ost_stats OSS ost stats
# TYPE lustre_oss_ost_stats gauge
lustre_oss_ost_stats{operation="req_waittime",units="usec"} 77655 1689840634153
lustre_oss_ost_stats{operation="req_qdepth",units="reqs"} 77655 1689840634153
lustre_oss_ost_stats{operation="req_active",units="reqs"} 77655 1689840634153
lustre_oss_ost_stats{operation="req_timeout",units="sec"} 77655 1689840634153
lustre_oss_ost_stats{operation="reqbuf_avail",units="bufs"} 157527 1689840634153
lustre_oss_ost_stats{operation="ldlm_glimpse_enqueue",units="reqs"} 42486 1689840634153
lustre_oss_ost_stats{operation="ldlm_extent_enqueue",units="reqs"} 17980 1689840634153
lustre_oss_ost_stats{operation="ost_create",units="usec"} 578 1689840634153
lustre_oss_ost_stats{operation="ost_destroy",units="usec"} 15361 1689840634153
lustre_oss_ost_stats{operation="ost_get_info",units="usec"} 8 1689840634153
```