### PR TITLE
Allow prometheus user to run `lnetctl`

### DIFF
--- a/debian/install
+++ b/debian/install
@@ -1,1 +1,2 @@
 /usr/bin/prometheus-lustrefs-exporter
+/etc/sudoers.d/prometheus

--- a/debian/rules
+++ b/debian/rules
@@ -14,7 +14,9 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	install -v -d debian/tmp/usr/bin
+	install -v -d debian/tmp/etc/sudoers.d/
 	install -v -T target/release/lustrefs-exporter debian/tmp/usr/bin/prometheus-lustrefs-exporter
+	install -v -T sudoers_file/prometheus debian/tmp/etc/sudoers.d/prometheus
 
 
 override_dh_auto_clean:

--- a/lustrefs_exporter.spec
+++ b/lustrefs_exporter.spec
@@ -19,14 +19,17 @@ cargo build --release
 %install
 install -v -d %{buildroot}%{_bindir}
 install -v -d %{buildroot}%{_unitdir}
+install -v -d %{buildroot}%{_sysconfdir}/sudoers.d/
 install -v -m 0644 lustrefs_exporter.service %{buildroot}%{_unitdir}
 install -v target/release/lustrefs-exporter %{buildroot}%{_bindir}
+install -v -m 0644 sudoers_file/prometheus %{buildroot}%{_sysconfdir}/sudoers.d/
 %{__ln_s} lustrefs-exporter %{buildroot}%{_bindir}/lustrefs_exporter
 
 %files
 %{_bindir}/lustrefs-exporter
 %{_bindir}/lustrefs_exporter
 %{_unitdir}/lustrefs_exporter.service
+%{_sysconfdir}/sudoers.d/prometheus
 
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
         output.append(&mut lctl_output);
 
         let lnetctl = Command::new("sudo")
-            .args(["lnetctl", "net", "show", "-v", "4"])
+            .args(["/usr/sbin/lnetctl", "net", "show", "-v", "4"])
             .kill_on_drop(true)
             .output()
             .await?;
@@ -47,7 +47,7 @@ async fn main() {
         output.append(&mut lnetctl_output);
 
         let lnetctl_stats_output = Command::new("sudo")
-            .args(["lnetctl", "stats", "show"])
+            .args(["/usr/sbin/lnetctl", "stats", "show"])
             .kill_on_drop(true)
             .output()
             .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,8 +36,8 @@ async fn main() {
         let mut lctl_output = parse_lctl_output(&lctl.stdout)?;
         output.append(&mut lctl_output);
 
-        let lnetctl = Command::new("lnetctl")
-            .args(["net", "show", "-v", "4"])
+        let lnetctl = Command::new("sudo")
+            .args(["lnetctl", "net", "show", "-v", "4"])
             .kill_on_drop(true)
             .output()
             .await?;
@@ -46,8 +46,8 @@ async fn main() {
         let mut lnetctl_output = parse_lnetctl_output(lnetctl_stats)?;
         output.append(&mut lnetctl_output);
 
-        let lnetctl_stats_output = Command::new("lnetctl")
-            .args(["stats", "show"])
+        let lnetctl_stats_output = Command::new("sudo")
+            .args(["lnetctl", "stats", "show"])
             .kill_on_drop(true)
             .output()
             .await?;

--- a/sudoers_file/prometheus
+++ b/sudoers_file/prometheus
@@ -1,1 +1,1 @@
-prometheus ALL=(ALL) NOPASSWD: /usr/sbin/lnetctl
+prometheus ALL=(ALL) NOPASSWD: /usr/sbin/lnetctl net show -v 4, /usr/sbin/lnetctl stats show

--- a/sudoers_file/prometheus
+++ b/sudoers_file/prometheus
@@ -1,0 +1,1 @@
+prometheus ALL=(ALL) NOPASSWD: /usr/sbin/lnetctl


### PR DESCRIPTION
`prometheus` user do not have enough permission to get `lnetctl` statistics.

Add it to the sudoers and allows passwordless sudo execution of `lnetctl`.