### PR TITLE
Add origin of the metric in help

### DIFF
--- a/src/brw_stats.rs
+++ b/src/brw_stats.rs
@@ -11,127 +11,129 @@ use crate::{
 
 static DISK_IO_TOTAL: Metric = Metric {
     name: "lustre_disk_io_total",
-    help: "Total number of operations the filesystem has performed for the given size.",
+    help: "Total number of operations the filesystem has performed for the given size. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Counter,
 };
 
 static DISK_IO_FRAGS: Metric = Metric {
     name: "lustre_dio_frags",
-    help: "Current disk IO fragmentation for the given size.",
+    help: "Current disk IO fragmentation for the given size. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Gauge,
 };
 
 static DISK_IO: Metric = Metric {
     name: "lustre_disk_io",
-    help: "Current number of I/O operations that are processing during the snapshot.",
+    help: "Current number of I/O operations that are processing during the snapshot. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Gauge,
 };
 
 static DISCONTIGUOUS_PAGES_TOTAL: Metric = Metric {
     name: "lustre_discontiguous_pages_total",
-    help: "Total number of logical discontinuities per RPC.",
+    help: "Total number of logical discontinuities per RPC. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Counter,
 };
 
 static DISCONTIGUOUS_BLOCKS_TOTAL: Metric = Metric {
     name: "lustre_discontiguous_blocks_total",
-    help: "",
+    help: "Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Counter,
 };
 
 static IO_TIME_MILLISECONDS_TOTAL: Metric = Metric {
     name: "lustre_io_time_milliseconds_total",
-    help: "Total time in milliseconds the filesystem has spent processing various object sizes.",
+    help: "Total time in milliseconds the filesystem has spent processing various object sizes. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Counter,
 };
 
 static PAGES_PER_BULK_RW_TOTAL: Metric = Metric {
     name: "lustre_pages_per_bulk_rw_total",
-    help: "Total number of pages per block RPC.",
+    help: "Total number of pages per block RPC. Originating from 'osd-*.*.brw_stats'",
     r#type: MetricType::Counter,
 };
 
 static INODES_FREE: Metric = Metric {
     name: "lustre_inodes_free",
-    help: "The number of inodes (objects) available",
+    help: "The number of inodes (objects) available. Originating from 'osd-*.*.filesfree'",
     r#type: MetricType::Gauge,
 };
 
 static INODES_MAXIMUM: Metric = Metric {
     name: "lustre_inodes_maximum",
-    help: "The maximum number of inodes (objects) the filesystem can hold",
+    help: "The maximum number of inodes (objects) the filesystem can hold. Originating from 'osd-*.*.filestotal'",
     r#type: MetricType::Gauge,
 };
 
 static AVAILABLE_KBYTES: Metric = Metric {
     name: "lustre_available_kilobytes",
-    help: "Number of kilobytes readily available in the pool",
+    help:
+        "Number of kilobytes readily available in the pool. Originating from 'osd-*.*.kbytesavail'",
     r#type: MetricType::Gauge,
 };
 
 static FREE_KBYTES: Metric = Metric {
     name: "lustre_free_kilobytes",
-    help: "Number of kilobytes allocated to the pool",
+    help: "Number of kilobytes allocated to the pool. Originating from 'osd-*.*.kbytesfree'",
     r#type: MetricType::Gauge,
 };
 
 static CAPACITY_KBYTES: Metric = Metric {
     name: "lustre_capacity_kilobytes",
-    help: "Capacity of the pool in kilobytes",
+    help: "Capacity of the pool in kilobytes. Originating from 'osd-*.*.kbytestotal'",
     r#type: MetricType::Gauge,
 };
 
 static EXPORTS_TOTAL: Metric = Metric {
     name: "lustre_exports_total",
-    help: "Total number of times the pool has been exported",
+    help: "Total number of times the pool has been exported. Originating from 'mgs.*.num_exports'/'mdt.*MDT*.num_exports'/'obdfilter.*OST*.num_exports' for MGT/MDT/OST",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_DIRTY_TOTAL: Metric = Metric {
     name: "lustre_exports_dirty_total",
-    help: "Total number of exports that have been marked dirty",
+    help: "Total number of exports that have been marked dirty. Originating from 'obdfilter.*OST*.tot_dirty'",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_GRANTED_TOTAL: Metric = Metric {
     name: "lustre_exports_granted_total",
-    help: "Total number of exports that have been marked granted",
+    help: "Total number of exports that have been marked granted. Originating from 'obdfilter.*OST*.tot_granted'",
     r#type: MetricType::Counter,
 };
 
 static EXPORTS_PENDING_TOTAL: Metric = Metric {
     name: "lustre_exports_pending_total",
-    help: "Total number of exports that have been marked pending",
+    help: "Total number of exports that have been marked pending. Originating from 'obdfilter.*OST*.tot_pending'",
     r#type: MetricType::Counter,
 };
 
 static LOCK_CONTENDED_TOTAL: Metric = Metric {
     name: "lustre_lock_contended_total",
-    help: "Number of contended locks",
+    help: "Number of contended locks. Originating from 'ldlm.namespaces.{mdt-,filter-}*.contended_locks'",
     r#type: MetricType::Counter,
 };
 
 static LOCK_CONTENTION_SECONDS_TOTAL: Metric = Metric {
     name: "lustre_lock_contention_seconds_total",
-    help: "Time in seconds during which locks were contended",
+    help: "Time in seconds during which locks were contended. Originating from 'ldlm.namespaces.{mdt-,filter-}*.contention_seconds'",
     r#type: MetricType::Counter,
 };
 
 static CONNECTED_CLIENTS: Metric = Metric {
     name: "lustre_connected_clients",
-    help: "Number of connected clients",
+    help: "Number of connected clients. Originating from 'mdt.*.exports.*.uuid'",
     r#type: MetricType::Gauge,
 };
 
 static LOCK_COUNT_TOTAL: Metric = Metric {
     name: "lustre_lock_count_total",
-    help: "Number of locks",
+    help: "Number of locks. Originating from 'ldlm.namespaces.{mdt-,filter-}*.lock_count'",
     r#type: MetricType::Counter,
 };
 
 static LOCK_TIMEOUT_TOTAL: Metric = Metric {
     name: "lustre_lock_timeout_total",
-    help: "Number of lock timeouts",
+    help:
+        "Number of lock timeouts. Originating from 'ldlm.namespaces.{mdt-,filter-}*.lock_timeouts'",
     r#type: MetricType::Counter,
 };
 
@@ -175,19 +177,19 @@ fn build_brw_stats(
 
 static OST_STATS: Metric = Metric {
     name: "lustre_oss_ost_stats",
-    help: "OSS ost stats",
+    help: "OSS ost stats. Originating from 'ost.OSS.ost.stats'",
     r#type: MetricType::Gauge,
 };
 
 static OST_IO_STATS: Metric = Metric {
     name: "lustre_oss_ost_io_stats",
-    help: "OSS ost_io stats",
+    help: "OSS ost_io stats. Originating from 'ost.OSS.ost_io.stats'",
     r#type: MetricType::Gauge,
 };
 
 static OST_CREATE_STATS: Metric = Metric {
     name: "lustre_oss_ost_create_stats",
-    help: "OSS ost_create stats",
+    help: "OSS ost_create stats. Originating from 'ost.OSS.ost_create.stats'",
     r#type: MetricType::Gauge,
 };
 

--- a/src/jobstats.rs
+++ b/src/jobstats.rs
@@ -6,43 +6,43 @@ use prometheus_exporter_base::{prelude::*, Yes};
 
 static READ_SAMPLES: Metric = Metric {
     name: "lustre_job_read_samples_total",
-    help: "Total number of reads that have been recorded.",
+    help: "Total number of reads that have been recorded. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Counter,
 };
 static READ_MIN_SIZE_BYTES: Metric = Metric {
     name: "lustre_job_read_minimum_size_bytes",
-    help: "The minimum read size in bytes.",
+    help: "The minimum read size in bytes. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Gauge,
 };
 static READ_MAX_SIZE_BYTES: Metric = Metric {
     name: "lustre_job_read_maximum_size_bytes",
-    help: "The maximum read size in bytes.",
+    help: "The maximum read size in bytes. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Gauge,
 };
 static READ_BYTES: Metric = Metric {
     name: "lustre_job_read_bytes_total",
-    help: "The total number of bytes that have been read.",
+    help: "The total number of bytes that have been read. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Counter,
 };
 
 static WRITE_SAMPLES: Metric = Metric {
     name: "lustre_job_write_samples_total",
-    help: "Total number of writes that have been recorded.",
+    help: "Total number of writes that have been recorded. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Counter,
 };
 static WRITE_MIN_SIZE_BYTES: Metric = Metric {
     name: "lustre_job_write_minimum_size_bytes",
-    help: "The minimum write size in bytes.",
+    help: "The minimum write size in bytes. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Gauge,
 };
 static WRITE_MAX_SIZE_BYTES: Metric = Metric {
     name: "lustre_job_write_maximum_size_bytes",
-    help: "The maximum write size in bytes.",
+    help: "The maximum write size in bytes. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Gauge,
 };
 static WRITE_BYTES: Metric = Metric {
     name: "lustre_job_write_bytes_total",
-    help: "The total number of bytes that have been written.",
+    help: "The total number of bytes that have been written. Originating from 'obdfilter.*OST*.job_stats'",
     r#type: MetricType::Counter,
 };
 
@@ -306,7 +306,7 @@ fn jobstatmdt_inst<'a>(
 
 static MDT_JOBSTATS_SAMPLES: Metric = Metric {
     name: "lustre_job_stats_total",
-    help: "Number of operations the filesystem has performed, recorded by jobstats.",
+    help: "Number of operations the filesystem has performed, recorded by jobstats. Originating from 'mdt.*.job_stats'",
     r#type: MetricType::Counter,
 };
 

--- a/src/lnet.rs
+++ b/src/lnet.rs
@@ -7,33 +7,35 @@ use crate::{Metric, StatsMapExt, ToMetricInst};
 
 static SEND_COUNT: Metric = Metric {
     name: "lustre_send_count_total",
-    help: "Total number of messages that have been sent",
+    help: "Total number of messages that have been sent. Originating from 'lnetctl net show -v 4'",
     r#type: MetricType::Counter,
 };
 static RECEIVE_COUNT: Metric = Metric {
     name: "lustre_receive_count_total",
-    help: "Total number of messages that have been received",
+    help:
+        "Total number of messages that have been received. Originating from 'lnetctl net show -v 4'",
     r#type: MetricType::Counter,
 };
 static DROP_COUNT: Metric = Metric {
     name: "lustre_drop_count_total",
-    help: "Total number of messages that have been dropped",
+    help:
+        "Total number of messages that have been dropped. Originating from 'lnetctl net show -v 4'",
     r#type: MetricType::Counter,
 };
 
 static SEND_BYTES: Metric = Metric {
     name: "lustre_send_bytes_total",
-    help: "Total number of bytes that have been sent",
+    help: "Total number of bytes that have been sent. Originating from 'lnetctl stats show'",
     r#type: MetricType::Counter,
 };
 static RECEIVE_BYTES: Metric = Metric {
     name: "lustre_receive_bytes_total",
-    help: "Total number of bytes that have been received",
+    help: "Total number of bytes that have been received. Originating from 'lnetctl stats show'",
     r#type: MetricType::Counter,
 };
 static DROP_BYTES: Metric = Metric {
     name: "lustre_drop_bytes_total",
-    help: "Total number of bytes that have been dropped",
+    help: "Total number of bytes that have been dropped. Originating from 'lnetctl stats show'",
     r#type: MetricType::Counter,
 };
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,13 +5,13 @@ use std::{collections::BTreeMap, ops::Deref, time::Duration};
 
 static LDLM_CANCELD_STATS_SAMPLES: Metric = Metric {
     name: "lustre_ldlm_canceld_stats",
-    help: "Gives information about LDLM Canceld service.",
+    help: "Gives information about LDLM Canceld service. Originating from 'ldlm.services.ldlm_canceld.stats'",
     r#type: MetricType::Counter,
 };
 
 static LDLM_CBD_STATS_SAMPLES: Metric = Metric {
     name: "lustre_ldlm_cbd_stats",
-    help: "Gives information about LDLM Callback service.",
+    help: "Gives information about LDLM Callback service. Originating from 'ldlm.services.ldlm_cbd.stats'",
     r#type: MetricType::Counter,
 };
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -6,43 +6,45 @@ use prometheus_exporter_base::prelude::*;
 
 static READ_SAMPLES: Metric = Metric {
     name: "lustre_read_samples_total",
-    help: "Total number of reads that have been recorded.",
+    help: "Total number of reads that have been recorded. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Counter,
 };
 static READ_MIN_SIZE_BYTES: Metric = Metric {
     name: "lustre_read_minimum_size_bytes",
-    help: "The minimum read size in bytes.",
+    help: "The minimum read size in bytes. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Gauge,
 };
 static READ_MAX_SIZE_BYTES: Metric = Metric {
     name: "lustre_read_maximum_size_bytes",
-    help: "The maximum read size in bytes.",
+    help: "The maximum read size in bytes. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Gauge,
 };
 static READ_BYTES: Metric = Metric {
     name: "lustre_read_bytes_total",
-    help: "The total number of bytes that have been read.",
+    help: "The total number of bytes that have been read. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Counter,
 };
 
 static WRITE_SAMPLES: Metric = Metric {
     name: "lustre_write_samples_total",
-    help: "Total number of writes that have been recorded.",
+    help:
+        "Total number of writes that have been recorded. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Counter,
 };
 static WRITE_MIN_SIZE_BYTES: Metric = Metric {
     name: "lustre_write_minimum_size_bytes",
-    help: "The minimum write size in bytes.",
+    help: "The minimum write size in bytes. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Gauge,
 };
 static WRITE_MAX_SIZE_BYTES: Metric = Metric {
     name: "lustre_write_maximum_size_bytes",
-    help: "The maximum write size in bytes.",
+    help: "The maximum write size in bytes. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Gauge,
 };
 static WRITE_BYTES: Metric = Metric {
     name: "lustre_write_bytes_total",
-    help: "The total number of bytes that have been written.",
+    help:
+        "The total number of bytes that have been written. Originating from 'obdfilter.*OST*.stats'",
     r#type: MetricType::Counter,
 };
 
@@ -160,7 +162,7 @@ pub fn build_ost_stats(
 
 static MDT_STATS_SAMPLES: Metric = Metric {
     name: "lustre_stats_total",
-    help: "Number of operations the filesystem has performed.",
+    help: "Number of operations the filesystem has performed. Originating from 'mdt.*.md_stats'",
     r#type: MetricType::Counter,
 };
 


### PR DESCRIPTION
New help, not all metrics are shown:
```
# HELP lustre_available_kilobytes Number of kilobytes readily available in the pool. Originating from 'osd-*.*.kbytesavail'
# HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes. Originating from 'osd-*.*.kbytestotal'
# HELP lustre_connected_clients Number of connected clients. Originating from 'mdt.*.exports.*.uuid'
# HELP lustre_dio_frags Current disk IO fragmentation for the given size. Originating from 'osd-*.*.brw_stats'
# HELP lustre_discontiguous_blocks_total Originating from 'osd-*.*.brw_stats'
# HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC. Originating from 'osd-*.*.brw_stats'
# HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot. Originating from 'osd-*.*.brw_stats'
# HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size. Originating from 'osd-*.*.brw_stats'
# HELP lustre_drop_bytes_total Total number of bytes that have been dropped. Originating from 'lnetctl stats show'
# HELP lustre_drop_count_total Total number of messages that have been dropped. Originating from 'lnetctl net show -v 4'
# HELP lustre_exports_dirty_total Total number of exports that have been marked dirty. Originating from 'obdfilter.*OST*.tot_dirty'
# HELP lustre_exports_granted_total Total number of exports that have been marked granted. Originating from 'obdfilter.*OST*.tot_granted'
# HELP lustre_exports_pending_total Total number of exports that have been marked pending. Originating from 'obdfilter.*OST*.tot_pending'
# HELP lustre_exports_total Total number of times the pool has been exported. Originating from 'mgs.*.num_exports'/'mdt.*MDT*.num_exports'/'obdfilter.*OST*.num_exports' for MGT/MDT/OST
# HELP lustre_free_kilobytes Number of kilobytes allocated to the pool. Originating from 'osd-*.*.kbytesfree'
# HELP lustre_inodes_free The number of inodes (objects) available. Originating from 'osd-*.*.filesfree'
# HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold. Originating from 'osd-*.*.filestotal'
# HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes. Originating from 'osd-*.*.brw_stats'
# HELP lustre_lock_contended_total Number of contended locks. Originating from 'ldlm.namespaces.{mdt-,filter-}*.contended_locks'
# HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended. Originating from 'ldlm.namespaces.{mdt-,filter-}*.contention_seconds'
# HELP lustre_lock_count_total Number of locks. Originating from 'ldlm.namespaces.{mdt-,filter-}*.lock_count'
# HELP lustre_lock_timeout_total Number of lock timeouts. Originating from 'ldlm.namespaces.{mdt-,filter-}*.lock_timeouts'
# HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC. Originating from 'osd-*.*.brw_stats'
# HELP lustre_read_bytes_total The total number of bytes that have been read. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_read_maximum_size_bytes The maximum read size in bytes. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_read_minimum_size_bytes The minimum read size in bytes. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_read_samples_total Total number of reads that have been recorded. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_receive_bytes_total Total number of bytes that have been received. Originating from 'lnetctl stats show'
# HELP lustre_receive_count_total Total number of messages that have been received. Originating from 'lnetctl net show -v 4'
# HELP lustre_send_bytes_total Total number of bytes that have been sent. Originating from 'lnetctl stats show'
# HELP lustre_send_count_total Total number of messages that have been sent. Originating from 'lnetctl net show -v 4'
# HELP lustre_stats_total Number of operations the filesystem has performed. Originating from 'mdt.*.md_stats'
# HELP lustre_write_bytes_total The total number of bytes that have been written. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_write_maximum_size_bytes The maximum write size in bytes. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_write_minimum_size_bytes The minimum write size in bytes. Originating from 'obdfilter.*OST*.stats'
# HELP lustre_write_samples_total Total number of writes that have been recorded. Originating from 'obdfilter.*OST*.stats' 
```