### PR TITLE
Disable timestamps

### DIFF
--- a/src/jobstats.rs
+++ b/src/jobstats.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::Deref, time::Duration};
+use std::{collections::BTreeMap, ops::Deref};
 
 use crate::{LabelProm, Metric, StatsMapExt};
 use lustre_collector::{JobStatMdt, JobStatOst, TargetStat};
@@ -61,56 +61,47 @@ fn jobstatost_inst<'a>(
     x: &'a JobStatOst,
     kind: &'a str,
     target: &'a str,
-    time: Duration,
 ) -> JobStatOstPromInst<'a> {
     let rs = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.read_bytes.samples)
-        .with_timestamp(time.as_millis());
+        .with_value(x.read_bytes.samples);
     let rmin = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.read_bytes.min)
-        .with_timestamp(time.as_millis());
+        .with_value(x.read_bytes.min);
     let rmax = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.read_bytes.max)
-        .with_timestamp(time.as_millis());
+        .with_value(x.read_bytes.max);
     let rb = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.read_bytes.sum)
-        .with_timestamp(time.as_millis());
+        .with_value(x.read_bytes.sum);
     let ws = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.write_bytes.samples)
-        .with_timestamp(time.as_millis());
+        .with_value(x.write_bytes.samples);
     let wmin = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.write_bytes.min)
-        .with_timestamp(time.as_millis());
+        .with_value(x.write_bytes.min);
     let wmax = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.write_bytes.max)
-        .with_timestamp(time.as_millis());
+        .with_value(x.write_bytes.max);
     let wb = PrometheusInstance::new()
         .with_label("component", kind)
         .with_label("target", target)
         .with_label("jobid", x.job_id.deref())
-        .with_value(x.write_bytes.sum)
-        .with_timestamp(time.as_millis());
+        .with_value(x.write_bytes.sum);
 
     (rs, rmin, rmax, rb, ws, wmin, wmax, wb)
 }
@@ -118,7 +109,6 @@ fn jobstatost_inst<'a>(
 pub fn build_ost_job_stats(
     x: TargetStat<Option<Vec<JobStatOst>>>,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     let TargetStat {
         kind,
@@ -134,7 +124,7 @@ pub fn build_ost_job_stats(
 
     for x in xs {
         let (rs, rmin, rmax, rb, ws, wmin, wmax, wb) =
-            jobstatost_inst(&x, kind.to_prom_label(), target.deref(), time);
+            jobstatost_inst(&x, kind.to_prom_label(), target.deref());
 
         stats_map
             .get_mut_metric(READ_SAMPLES)
@@ -186,7 +176,6 @@ fn jobstatmdt_inst<'a>(
     x: &'a JobStatMdt,
     kind: &'a str,
     target: &'a str,
-    time: Duration,
 ) -> JobStatMdtPromInst<'a> {
     (
         PrometheusInstance::new()
@@ -194,113 +183,97 @@ fn jobstatmdt_inst<'a>(
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "open")
-            .with_value(x.open.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.open.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "close")
-            .with_value(x.close.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.close.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "mknod")
-            .with_value(x.mknod.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.mknod.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "link")
-            .with_value(x.link.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.link.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "unlink")
-            .with_value(x.unlink.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.unlink.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "mkdir")
-            .with_value(x.mkdir.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.mkdir.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "rmdir")
-            .with_value(x.rmdir.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.rmdir.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "rename")
-            .with_value(x.rename.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.rename.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "getattr")
-            .with_value(x.getattr.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.getattr.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "setattr")
-            .with_value(x.setattr.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.setattr.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "getxattr")
-            .with_value(x.getxattr.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.getxattr.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "setxattr")
-            .with_value(x.setxattr.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.setxattr.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "statfs")
-            .with_value(x.statfs.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.statfs.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "sync")
-            .with_value(x.sync.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.sync.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "samedir_rename")
-            .with_value(x.samedir_rename.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.samedir_rename.samples),
         PrometheusInstance::new()
             .with_label("component", kind)
             .with_label("target", target)
             .with_label("jobid", x.job_id.deref())
             .with_label("operation", "crossdir_rename")
-            .with_value(x.crossdir_rename.samples)
-            .with_timestamp(time.as_millis()),
+            .with_value(x.crossdir_rename.samples),
     )
 }
 
@@ -313,7 +286,6 @@ static MDT_JOBSTATS_SAMPLES: Metric = Metric {
 pub fn build_mdt_job_stats(
     x: TargetStat<Option<Vec<JobStatMdt>>>,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     let TargetStat {
         kind,
@@ -345,7 +317,7 @@ pub fn build_mdt_job_stats(
             sync,
             samedir_rename,
             crossdir_rename,
-        ) = jobstatmdt_inst(&x, kind.to_prom_label(), target.deref(), time);
+        ) = jobstatmdt_inst(&x, kind.to_prom_label(), target.deref());
 
         stats_map
             .get_mut_metric(MDT_JOBSTATS_SAMPLES)

--- a/src/lnet.rs
+++ b/src/lnet.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, time::Duration};
+use std::collections::BTreeMap;
 
 use lustre_collector::LNetStats;
 use prometheus_exporter_base::prelude::*;
@@ -40,38 +40,37 @@ static DROP_BYTES: Metric = Metric {
 pub fn build_lnet_stats(
     x: LNetStats,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     match x {
         LNetStats::SendCount(x) => {
             stats_map
                 .get_mut_metric(SEND_COUNT)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
         LNetStats::RecvCount(x) => {
             stats_map
                 .get_mut_metric(RECEIVE_COUNT)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
         LNetStats::DropCount(x) => {
             stats_map
                 .get_mut_metric(DROP_COUNT)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
         LNetStats::SendLength(x) => {
             stats_map
                 .get_mut_metric(SEND_BYTES)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
         LNetStats::RecvLength(x) => {
             stats_map
                 .get_mut_metric(RECEIVE_BYTES)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
         LNetStats::DropLength(x) => {
             stats_map
                 .get_mut_metric(DROP_BYTES)
-                .render_and_append_instance(&x.to_metric_inst(time));
+                .render_and_append_instance(&x.to_metric_inst());
         }
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 use lustre_collector::{parse_lctl_output, parse_lnetctl_output, parse_lnetctl_stats, parser};
 use lustrefs_exporter::build_lustre_stats;
 use prometheus_exporter_base::prelude::*;
-use std::time::{SystemTime, UNIX_EPOCH};
+
 use tokio::process::Command;
 
 #[derive(Debug)]
@@ -22,8 +22,6 @@ async fn main() {
 
     render_prometheus(server_opts, Options, |request, options| async move {
         tracing::debug!(?request, ?options);
-
-        let time = SystemTime::now().duration_since(UNIX_EPOCH)?;
 
         let mut output = vec![];
 
@@ -60,7 +58,7 @@ async fn main() {
 
         output.append(&mut lnetctl_stats_record);
 
-        Ok(build_lustre_stats(output, time))
+        Ok(build_lustre_stats(output))
     })
     .await;
 }
@@ -68,7 +66,6 @@ async fn main() {
 #[cfg(test)]
 mod tests {
     use crate::build_lustre_stats;
-    use std::time::UNIX_EPOCH;
 
     #[test]
     fn test_stats() {
@@ -76,7 +73,7 @@ mod tests {
 
         let x = serde_json::from_str(output).unwrap();
 
-        let x = build_lustre_stats(x, UNIX_EPOCH.duration_since(UNIX_EPOCH).unwrap());
+        let x = build_lustre_stats(x);
 
         insta::assert_display_snapshot!(x);
     }
@@ -86,7 +83,7 @@ mod tests {
 
         let x = serde_json::from_str(output).unwrap();
 
-        let x = build_lustre_stats(x, UNIX_EPOCH.duration_since(UNIX_EPOCH).unwrap());
+        let x = build_lustre_stats(x);
 
         insta::assert_display_snapshot!(x);
     }
@@ -96,7 +93,7 @@ mod tests {
 
         let x = serde_json::from_str(output).unwrap();
 
-        let x = build_lustre_stats(x, UNIX_EPOCH.duration_since(UNIX_EPOCH).unwrap());
+        let x = build_lustre_stats(x);
 
         insta::assert_display_snapshot!(x);
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,7 +1,7 @@
 use crate::{Metric, StatsMapExt};
 use lustre_collector::LustreServiceStats;
 use prometheus_exporter_base::prelude::*;
-use std::{collections::BTreeMap, ops::Deref, time::Duration};
+use std::{collections::BTreeMap, ops::Deref};
 
 static LDLM_CANCELD_STATS_SAMPLES: Metric = Metric {
     name: "lustre_ldlm_canceld_stats",
@@ -18,7 +18,6 @@ static LDLM_CBD_STATS_SAMPLES: Metric = Metric {
 pub fn build_service_stats(
     x: LustreServiceStats,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     match x {
         LustreServiceStats::LdlmCanceld(xs) => {
@@ -28,8 +27,7 @@ pub fn build_service_stats(
                     .render_and_append_instance(
                         &PrometheusInstance::new()
                             .with_label("operation", s.name.deref())
-                            .with_value(s.samples)
-                            .with_timestamp(time.as_millis()),
+                            .with_value(s.samples),
                     );
             }
         }
@@ -40,8 +38,7 @@ pub fn build_service_stats(
                     .render_and_append_instance(
                         &PrometheusInstance::new()
                             .with_label("operation", s.name.deref())
-                            .with_value(s.samples)
-                            .with_timestamp(time.as_millis()),
+                            .with_value(s.samples),
                     );
             }
         }

--- a/src/snapshots/lustrefs_exporter__tests__jobstats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__jobstats.snap
@@ -4,353 +4,353 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 474824704 0
-lustre_available_kilobytes{component="mdt",target="fs-MDT0000"} 2423201792 0
-lustre_available_kilobytes{component="ost",target="fs-OST0000"} 4135227392 0
-lustre_available_kilobytes{component="ost",target="fs-OST0001"} 4135227392 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 474824704
+lustre_available_kilobytes{component="mdt",target="fs-MDT0000"} 2423201792
+lustre_available_kilobytes{component="ost",target="fs-OST0000"} 4135227392
+lustre_available_kilobytes{component="ost",target="fs-OST0001"} 4135227392
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 502878208 0
-lustre_capacity_kilobytes{component="mdt",target="fs-MDT0000"} 2665299968 0
-lustre_capacity_kilobytes{component="ost",target="fs-OST0000"} 4206989312 0
-lustre_capacity_kilobytes{component="ost",target="fs-OST0001"} 4206989312 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 502878208
+lustre_capacity_kilobytes{component="mdt",target="fs-MDT0000"} 2665299968
+lustre_capacity_kilobytes{component="ost",target="fs-OST0000"} 4206989312
+lustre_capacity_kilobytes{component="ost",target="fs-OST0001"} 4206989312
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
-lustre_connected_clients{component="mdt",target="fs-MDT0000"} 1 0
-lustre_connected_clients{component="mdt",target="fs-MDT0000"} 1 0
+lustre_connected_clients{component="mdt",target="fs-MDT0000"} 1
+lustre_connected_clients{component="mdt",target="fs-MDT0000"} 1
 
 # HELP lustre_dio_frags Current disk IO fragmentation for the given size.
 # TYPE lustre_dio_frags gauge
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="2"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="2"} 4 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="4"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="4"} 1 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="6"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="6"} 2 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="8"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="8"} 11 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="1"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="1"} 1 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="2"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="2"} 5 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="4"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="4"} 1 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="5"} 1 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="6"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="6"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="8"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="8"} 12 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="2"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="2"} 4
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="3"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="3"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="4"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="4"} 1
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="5"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="5"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="6"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="6"} 2
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="7"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="7"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0000",size="8"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0000",size="8"} 11
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="1"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="1"} 1
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="2"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="2"} 5
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="3"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="3"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="4"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="4"} 1
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="5"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="5"} 1
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="6"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="6"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="7"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="7"} 0
+lustre_dio_frags{component="ost",operation="read",target="fs-OST0001",size="8"} 0
+lustre_dio_frags{component="ost",operation="write",target="fs-OST0001",size="8"} 12
 
 # HELP lustre_discontiguous_blocks_total 
 # TYPE lustre_discontiguous_blocks_total counter
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0000",size="0"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0000",size="0"} 17 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0000",size="1"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0000",size="1"} 1 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0001",size="0"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0001",size="0"} 19 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0001",size="1"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0001",size="1"} 1 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0000",size="0"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0000",size="0"} 17
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0000",size="1"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0000",size="1"} 1
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0001",size="0"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0001",size="0"} 19
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="fs-OST0001",size="1"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="fs-OST0001",size="1"} 1
 
 # HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
 # TYPE lustre_discontiguous_pages_total counter
-lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0000",size="0"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0000",size="0"} 17 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0000",size="1"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0000",size="1"} 1 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0001",size="0"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0001",size="0"} 19 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0001",size="1"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0001",size="1"} 1 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0000",size="0"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0000",size="0"} 17
+lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0000",size="1"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0000",size="1"} 1
+lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0001",size="0"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0001",size="0"} 19
+lustre_discontiguous_pages_total{component="ost",operation="read",target="fs-OST0001",size="1"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="fs-OST0001",size="1"} 1
 
 # HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
 # TYPE lustre_disk_io gauge
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="1"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="1"} 13 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="2"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="2"} 18 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="3"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="3"} 29 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="4"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="4"} 19 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="5"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="5"} 14 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="6"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="6"} 11 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="7"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="7"} 6 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="8"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="8"} 1 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="9"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="9"} 1 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="1"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="1"} 15 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="2"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="2"} 17 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="3"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="3"} 23 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="4"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="4"} 16 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="5"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="5"} 15 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="6"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="6"} 13 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="7"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="7"} 6 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="8"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="8"} 2 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="9"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="9"} 2 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="10"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="10"} 1 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="11"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="11"} 4 0
-lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="12"} 0 0
-lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="12"} 2 0
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="1"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="1"} 13
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="2"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="2"} 18
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="3"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="3"} 29
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="4"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="4"} 19
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="5"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="5"} 14
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="6"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="6"} 11
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="7"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="7"} 6
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="8"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="8"} 1
+lustre_disk_io{component="ost",operation="read",target="fs-OST0000",size="9"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0000",size="9"} 1
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="1"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="1"} 15
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="2"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="2"} 17
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="3"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="3"} 23
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="4"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="4"} 16
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="5"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="5"} 15
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="6"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="6"} 13
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="7"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="7"} 6
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="8"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="8"} 2
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="9"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="9"} 2
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="10"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="10"} 1
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="11"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="11"} 4
+lustre_disk_io{component="ost",operation="read",target="fs-OST0001",size="12"} 0
+lustre_disk_io{component="ost",operation="write",target="fs-OST0001",size="12"} 2
 
 # HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
 # TYPE lustre_disk_io_total counter
-lustre_disk_io_total{component="ost",operation="read",target="fs-OST0000",size="524288"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="fs-OST0000",size="524288"} 112 0
-lustre_disk_io_total{component="ost",operation="read",target="fs-OST0001",size="524288"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="fs-OST0001",size="524288"} 116 0
+lustre_disk_io_total{component="ost",operation="read",target="fs-OST0000",size="524288"} 0
+lustre_disk_io_total{component="ost",operation="write",target="fs-OST0000",size="524288"} 112
+lustre_disk_io_total{component="ost",operation="read",target="fs-OST0001",size="524288"} 0
+lustre_disk_io_total{component="ost",operation="write",target="fs-OST0001",size="524288"} 116
 
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
-lustre_drop_count_total{nid="0@lo"} 3 0
-lustre_drop_count_total{nid="10.73.20.11@tcp"} 5 0
-lustre_drop_count_total{nid="10.73.20.51@tcp"} 6 0
+lustre_drop_count_total{nid="0@lo"} 3
+lustre_drop_count_total{nid="10.73.20.11@tcp"} 5
+lustre_drop_count_total{nid="10.73.20.51@tcp"} 6
 
 # HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
 # TYPE lustre_exports_dirty_total counter
-lustre_exports_dirty_total{component="ost",target="fs-OST0000"} 0 0
-lustre_exports_dirty_total{component="ost",target="fs-OST0001"} 0 0
+lustre_exports_dirty_total{component="ost",target="fs-OST0000"} 0
+lustre_exports_dirty_total{component="ost",target="fs-OST0001"} 0
 
 # HELP lustre_exports_granted_total Total number of exports that have been marked granted
 # TYPE lustre_exports_granted_total counter
-lustre_exports_granted_total{component="ost",target="fs-OST0000"} 98188992 0
-lustre_exports_granted_total{component="ost",target="fs-OST0001"} 113017408 0
+lustre_exports_granted_total{component="ost",target="fs-OST0000"} 98188992
+lustre_exports_granted_total{component="ost",target="fs-OST0001"} 113017408
 
 # HELP lustre_exports_pending_total Total number of exports that have been marked pending
 # TYPE lustre_exports_pending_total counter
-lustre_exports_pending_total{component="ost",target="fs-OST0000"} 0 0
-lustre_exports_pending_total{component="ost",target="fs-OST0001"} 0 0
+lustre_exports_pending_total{component="ost",target="fs-OST0000"} 0
+lustre_exports_pending_total{component="ost",target="fs-OST0001"} 0
 
 # HELP lustre_exports_total Total number of times the pool has been exported
 # TYPE lustre_exports_total counter
-lustre_exports_total{component="mgt",target="MGS"} 4 0
-lustre_exports_total{component="ost",target="fs-OST0000"} 2 0
-lustre_exports_total{component="ost",target="fs-OST0001"} 2 0
-lustre_exports_total{component="mdt",target="fs-MDT0000"} 10 0
+lustre_exports_total{component="mgt",target="MGS"} 4
+lustre_exports_total{component="ost",target="fs-OST0000"} 2
+lustre_exports_total{component="ost",target="fs-OST0001"} 2
+lustre_exports_total{component="mdt",target="fs-MDT0000"} 10
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 501665792 0
-lustre_free_kilobytes{component="mdt",target="fs-MDT0000"} 2662928384 0
-lustre_free_kilobytes{component="ost",target="fs-OST0000"} 4205690880 0
-lustre_free_kilobytes{component="ost",target="fs-OST0001"} 4205690880 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 501665792
+lustre_free_kilobytes{component="mdt",target="fs-MDT0000"} 2662928384
+lustre_free_kilobytes{component="ost",target="fs-OST0000"} 4205690880
+lustre_free_kilobytes{component="ost",target="fs-OST0001"} 4205690880
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge
-lustre_inodes_free{component="mgt",target="MGS"} 32570 0
-lustre_inodes_free{component="mdt",target="fs-MDT0000"} 1885348 0
-lustre_inodes_free{component="ost",target="fs-OST0000"} 40628 0
-lustre_inodes_free{component="ost",target="fs-OST0001"} 40628 0
+lustre_inodes_free{component="mgt",target="MGS"} 32570
+lustre_inodes_free{component="mdt",target="fs-MDT0000"} 1885348
+lustre_inodes_free{component="ost",target="fs-OST0000"} 40628
+lustre_inodes_free{component="ost",target="fs-OST0001"} 40628
 
 # HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
 # TYPE lustre_inodes_maximum gauge
-lustre_inodes_maximum{component="mgt",target="MGS"} 32768 0
-lustre_inodes_maximum{component="mdt",target="fs-MDT0000"} 1885696 0
-lustre_inodes_maximum{component="ost",target="fs-OST0000"} 40960 0
-lustre_inodes_maximum{component="ost",target="fs-OST0001"} 40960 0
+lustre_inodes_maximum{component="mgt",target="MGS"} 32768
+lustre_inodes_maximum{component="mdt",target="fs-MDT0000"} 1885696
+lustre_inodes_maximum{component="ost",target="fs-OST0000"} 40960
+lustre_inodes_maximum{component="ost",target="fs-OST0001"} 40960
 
 # HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
 # TYPE lustre_io_time_milliseconds_total counter
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="16"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="16"} 2 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="32"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="32"} 4 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="64"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="64"} 9 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="128"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="128"} 3 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="16"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="16"} 1 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="32"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="32"} 10 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="64"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="64"} 5 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="128"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="128"} 4 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="16"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="16"} 2
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="32"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="32"} 4
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="64"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="64"} 9
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0000",size="128"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0000",size="128"} 3
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="16"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="16"} 1
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="32"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="32"} 10
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="64"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="64"} 5
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="fs-OST0001",size="128"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="fs-OST0001",size="128"} 4
 
 # HELP lustre_job_read_bytes_total The total number of bytes that have been read.
 # TYPE lustre_job_read_bytes_total counter
-lustre_job_read_bytes_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_bytes_total{component="ost",target="fs-OST0000",jobid="dd.0"} 0 0
-lustre_job_read_bytes_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_bytes_total{component="ost",target="fs-OST0001",jobid="dd.0"} 0 0
+lustre_job_read_bytes_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_read_bytes_total{component="ost",target="fs-OST0000",jobid="dd.0"} 0
+lustre_job_read_bytes_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_read_bytes_total{component="ost",target="fs-OST0001",jobid="dd.0"} 0
 
 # HELP lustre_job_read_maximum_size_bytes The maximum read size in bytes.
 # TYPE lustre_job_read_maximum_size_bytes gauge
-lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 0 0
-lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 0 0
+lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 0
+lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_read_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 0
 
 # HELP lustre_job_read_minimum_size_bytes The minimum read size in bytes.
 # TYPE lustre_job_read_minimum_size_bytes gauge
-lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 0 0
-lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 0 0
+lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 0
+lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_read_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 0
 
 # HELP lustre_job_read_samples_total Total number of reads that have been recorded.
 # TYPE lustre_job_read_samples_total counter
-lustre_job_read_samples_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_samples_total{component="ost",target="fs-OST0000",jobid="dd.0"} 0 0
-lustre_job_read_samples_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_read_samples_total{component="ost",target="fs-OST0001",jobid="dd.0"} 0 0
+lustre_job_read_samples_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_read_samples_total{component="ost",target="fs-OST0000",jobid="dd.0"} 0
+lustre_job_read_samples_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_read_samples_total{component="ost",target="fs-OST0001",jobid="dd.0"} 0
 
 # HELP lustre_job_stats_total Number of operations the filesystem has performed, recorded by jobstats.
 # TYPE lustre_job_stats_total counter
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="open"} 1 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="close"} 4 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="mknod"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="link"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="unlink"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="mkdir"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="rmdir"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="rename"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="getattr"} 3 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="setattr"} 4 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="getxattr"} 1 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="setxattr"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="statfs"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="sync"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="samedir_rename"} 0 0
-lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="crossdir_rename"} 0 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="open"} 1
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="close"} 4
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="mknod"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="link"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="unlink"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="mkdir"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="rmdir"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="rename"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="getattr"} 3
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="setattr"} 4
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="getxattr"} 1
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="setxattr"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="statfs"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="sync"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="samedir_rename"} 0
+lustre_job_stats_total{component="mdt",target="fs-MDT0000",jobid="dd.0",operation="crossdir_rename"} 0
 
 # HELP lustre_job_write_bytes_total The total number of bytes that have been written.
 # TYPE lustre_job_write_bytes_total counter
-lustre_job_write_bytes_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_bytes_total{component="ost",target="fs-OST0000",jobid="dd.0"} 57671680 0
-lustre_job_write_bytes_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_bytes_total{component="ost",target="fs-OST0001",jobid="dd.0"} 59670528 0
+lustre_job_write_bytes_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_write_bytes_total{component="ost",target="fs-OST0000",jobid="dd.0"} 57671680
+lustre_job_write_bytes_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_write_bytes_total{component="ost",target="fs-OST0001",jobid="dd.0"} 59670528
 
 # HELP lustre_job_write_maximum_size_bytes The maximum write size in bytes.
 # TYPE lustre_job_write_maximum_size_bytes gauge
-lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 4194304 0
-lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 4194304 0
+lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 4194304
+lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_write_maximum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 4194304
 
 # HELP lustre_job_write_minimum_size_bytes The minimum write size in bytes.
 # TYPE lustre_job_write_minimum_size_bytes gauge
-lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 1048576 0
-lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 524288 0
+lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0000",jobid="dd.0"} 1048576
+lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_write_minimum_size_bytes{component="ost",target="fs-OST0001",jobid="dd.0"} 524288
 
 # HELP lustre_job_write_samples_total Total number of writes that have been recorded.
 # TYPE lustre_job_write_samples_total counter
-lustre_job_write_samples_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_samples_total{component="ost",target="fs-OST0000",jobid="dd.0"} 17 0
-lustre_job_write_samples_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0 0
-lustre_job_write_samples_total{component="ost",target="fs-OST0001",jobid="dd.0"} 19 0
+lustre_job_write_samples_total{component="ost",target="fs-OST0000",jobid="kworker/2:2.0"} 0
+lustre_job_write_samples_total{component="ost",target="fs-OST0000",jobid="dd.0"} 17
+lustre_job_write_samples_total{component="ost",target="fs-OST0001",jobid="kworker/2:2.0"} 0
+lustre_job_write_samples_total{component="ost",target="fs-OST0001",jobid="dd.0"} 19
 
 # HELP lustre_lock_contended_total Number of contended locks
 # TYPE lustre_lock_contended_total counter
-lustre_lock_contended_total{component="mdt",target="fs-MDT0000"} 32 0
-lustre_lock_contended_total{component="ost",target="fs-OST0000"} 32 0
-lustre_lock_contended_total{component="ost",target="fs-OST0001"} 32 0
+lustre_lock_contended_total{component="mdt",target="fs-MDT0000"} 32
+lustre_lock_contended_total{component="ost",target="fs-OST0000"} 32
+lustre_lock_contended_total{component="ost",target="fs-OST0001"} 32
 
 # HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended
 # TYPE lustre_lock_contention_seconds_total counter
-lustre_lock_contention_seconds_total{component="mdt",target="fs-MDT0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="fs-OST0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="fs-OST0001"} 2 0
+lustre_lock_contention_seconds_total{component="mdt",target="fs-MDT0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="fs-OST0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="fs-OST0001"} 2
 
 # HELP lustre_lock_count_total Number of locks
 # TYPE lustre_lock_count_total counter
-lustre_lock_count_total{component="mdt",target="fs-MDT0000"} 32 0
-lustre_lock_count_total{component="ost",target="fs-OST0000"} 1 0
-lustre_lock_count_total{component="ost",target="fs-OST0001"} 1 0
+lustre_lock_count_total{component="mdt",target="fs-MDT0000"} 32
+lustre_lock_count_total{component="ost",target="fs-OST0000"} 1
+lustre_lock_count_total{component="ost",target="fs-OST0001"} 1
 
 # HELP lustre_lock_timeout_total Number of lock timeouts
 # TYPE lustre_lock_timeout_total counter
-lustre_lock_timeout_total{component="mdt",target="fs-MDT0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="fs-OST0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="fs-OST0001"} 0 0
+lustre_lock_timeout_total{component="mdt",target="fs-MDT0000"} 0
+lustre_lock_timeout_total{component="ost",target="fs-OST0000"} 0
+lustre_lock_timeout_total{component="ost",target="fs-OST0001"} 0
 
 # HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
 # TYPE lustre_pages_per_bulk_rw_total counter
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="256"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="256"} 4 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="512"} 1 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="1024"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="1024"} 13 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="128"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="128"} 1 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="256"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="256"} 5 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="512"} 1 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="1024"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="1024"} 13 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="256"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="256"} 4
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="512"} 1
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0000",size="1024"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0000",size="1024"} 13
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="128"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="128"} 1
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="256"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="256"} 5
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="512"} 1
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="fs-OST0001",size="1024"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="fs-OST0001",size="1024"} 13
 
 # HELP lustre_receive_count_total Total number of messages that have been received
 # TYPE lustre_receive_count_total counter
-lustre_receive_count_total{nid="0@lo"} 27011 0
-lustre_receive_count_total{nid="10.73.20.11@tcp"} 25960 0
-lustre_receive_count_total{nid="10.73.20.51@tcp"} 25880 0
+lustre_receive_count_total{nid="0@lo"} 27011
+lustre_receive_count_total{nid="10.73.20.11@tcp"} 25960
+lustre_receive_count_total{nid="10.73.20.51@tcp"} 25880
 
 # HELP lustre_send_count_total Total number of messages that have been sent
 # TYPE lustre_send_count_total counter
-lustre_send_count_total{nid="0@lo"} 27014 0
-lustre_send_count_total{nid="10.73.20.11@tcp"} 25956 0
-lustre_send_count_total{nid="10.73.20.51@tcp"} 25870 0
+lustre_send_count_total{nid="0@lo"} 27014
+lustre_send_count_total{nid="10.73.20.11@tcp"} 25956
+lustre_send_count_total{nid="10.73.20.51@tcp"} 25870
 
 # HELP lustre_stats_total Number of operations the filesystem has performed.
 # TYPE lustre_stats_total counter
-lustre_stats_total{component="mdt",operation="open",target="fs-MDT0000"} 4 0
-lustre_stats_total{component="mdt",operation="close",target="fs-MDT0000"} 11 0
-lustre_stats_total{component="mdt",operation="mknod",target="fs-MDT0000"} 2 0
-lustre_stats_total{component="mdt",operation="getattr",target="fs-MDT0000"} 15 0
-lustre_stats_total{component="mdt",operation="setattr",target="fs-MDT0000"} 7 0
-lustre_stats_total{component="mdt",operation="getxattr",target="fs-MDT0000"} 2 0
-lustre_stats_total{component="mdt",operation="statfs",target="fs-MDT0000"} 3 0
+lustre_stats_total{component="mdt",operation="open",target="fs-MDT0000"} 4
+lustre_stats_total{component="mdt",operation="close",target="fs-MDT0000"} 11
+lustre_stats_total{component="mdt",operation="mknod",target="fs-MDT0000"} 2
+lustre_stats_total{component="mdt",operation="getattr",target="fs-MDT0000"} 15
+lustre_stats_total{component="mdt",operation="setattr",target="fs-MDT0000"} 7
+lustre_stats_total{component="mdt",operation="getxattr",target="fs-MDT0000"} 2
+lustre_stats_total{component="mdt",operation="statfs",target="fs-MDT0000"} 3
 
 # HELP lustre_write_bytes_total The total number of bytes that have been written.
 # TYPE lustre_write_bytes_total counter
-lustre_write_bytes_total{component="ost",operation="write",target="fs-OST0000"} 58720256 0
-lustre_write_bytes_total{component="ost",operation="write",target="fs-OST0001"} 60719104 0
+lustre_write_bytes_total{component="ost",operation="write",target="fs-OST0000"} 58720256
+lustre_write_bytes_total{component="ost",operation="write",target="fs-OST0001"} 60719104
 
 # HELP lustre_write_maximum_size_bytes The maximum write size in bytes.
 # TYPE lustre_write_maximum_size_bytes gauge
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="fs-OST0000"} 4194304 0
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="fs-OST0001"} 4194304 0
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="fs-OST0000"} 4194304
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="fs-OST0001"} 4194304
 
 # HELP lustre_write_minimum_size_bytes The minimum write size in bytes.
 # TYPE lustre_write_minimum_size_bytes gauge
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="fs-OST0000"} 1048576 0
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="fs-OST0001"} 524288 0
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="fs-OST0000"} 1048576
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="fs-OST0001"} 524288
 
 # HELP lustre_write_samples_total Total number of writes that have been recorded.
 # TYPE lustre_write_samples_total counter
-lustre_write_samples_total{component="ost",operation="write",target="fs-OST0000"} 18 0
-lustre_write_samples_total{component="ost",operation="write",target="fs-OST0001"} 20 0
+lustre_write_samples_total{component="ost",operation="write",target="fs-OST0000"} 18
+lustre_write_samples_total{component="ost",operation="write",target="fs-OST0001"} 20
 

--- a/src/snapshots/lustrefs_exporter__tests__lnetctl_stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__lnetctl_stats.snap
@@ -4,428 +4,428 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 1918787584 0
-lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 429908463616 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 2035205947392 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 935672266752 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 1918787584
+lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 429908463616
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 2035205947392
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 935672266752
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 2027556864 0
-lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437423087616 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 35584435134464 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 35584435134464 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 2027556864
+lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437423087616
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 35584435134464
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 35584435134464
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 17 0
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 17 0
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 17
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 17
 
 # HELP lustre_dio_frags Current disk IO fragmentation for the given size.
 # TYPE lustre_dio_frags gauge
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 51611589 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 7603209 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 51626985 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 8646209 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 1 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 51611589
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 7603209
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 51626985
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 8646209
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 1
 
 # HELP lustre_discontiguous_blocks_total 
 # TYPE lustre_discontiguous_blocks_total counter
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 51611589 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 7603209 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 51626985 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 8646208 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 2 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 51611589
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 7603209
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 51626985
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 8646208
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 2
 
 # HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
 # TYPE lustre_discontiguous_pages_total counter
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 51611589 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 7603209 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 51626985 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 8646209 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 1 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 51611589
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 7603209
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 51626985
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 8646209
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 1
 
 # HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
 # TYPE lustre_disk_io gauge
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 4492529 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 894259 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 6799272 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 993140 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 7465620 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 830673 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 6993678 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 575849 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 5917727 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 358188 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 4689595 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 212394 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 3576642 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 132071 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 2674667 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 94110 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="9"} 1991081 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="9"} 76508 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="10"} 1484763 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="10"} 67161 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="11"} 1118017 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="11"} 61625 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="12"} 849330 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="12"} 57544 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="13"} 653531 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="13"} 54693 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="14"} 507883 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="14"} 52871 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="15"} 399199 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="15"} 50963 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 316747 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 49484 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="17"} 254196 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="17"} 48189 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="18"} 206067 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="18"} 47520 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="19"} 168448 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="19"} 47118 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="20"} 139592 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="20"} 47338 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="21"} 116570 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="21"} 47765 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="22"} 97623 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="22"} 48445 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="23"} 82223 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="23"} 48671 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="24"} 69763 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="24"} 49193 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="25"} 59751 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="25"} 49538 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="26"} 51833 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="26"} 49544 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="27"} 44996 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="27"} 49587 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="28"} 38990 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="28"} 49794 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="29"} 34401 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="29"} 50122 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="30"} 30195 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="30"} 50427 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="31"} 286660 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="31"} 2358425 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 4476608 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 815593 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 6791400 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 853235 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 7478418 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 773235 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 7021213 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 643406 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 5950957 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 470799 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 4722125 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 302514 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 3605626 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 182730 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 2697883 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 116490 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 2008146 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 85422 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 1498168 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 72273 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 1125087 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 66624 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 853180 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 65250 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 653855 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 65514 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 505382 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 66674 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 395248 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 68275 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 311543 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 69392 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 247324 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 69429 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 198730 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 69505 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 161045 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 69345 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 130775 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 68863 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 107813 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 68159 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 89200 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 67718 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 74413 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 67188 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 62751 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 67234 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 52716 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 67165 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 44943 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 67431 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 38343 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 67752 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 33035 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 68202 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 28458 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 68542 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 24796 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 68805 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 237804 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 2973447 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 4492529
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 894259
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 6799272
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 993140
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 7465620
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 830673
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 6993678
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 575849
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 5917727
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 358188
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 4689595
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 212394
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 3576642
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 132071
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 2674667
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 94110
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="9"} 1991081
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="9"} 76508
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="10"} 1484763
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="10"} 67161
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="11"} 1118017
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="11"} 61625
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="12"} 849330
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="12"} 57544
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="13"} 653531
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="13"} 54693
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="14"} 507883
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="14"} 52871
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="15"} 399199
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="15"} 50963
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 316747
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 49484
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="17"} 254196
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="17"} 48189
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="18"} 206067
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="18"} 47520
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="19"} 168448
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="19"} 47118
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="20"} 139592
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="20"} 47338
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="21"} 116570
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="21"} 47765
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="22"} 97623
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="22"} 48445
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="23"} 82223
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="23"} 48671
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="24"} 69763
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="24"} 49193
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="25"} 59751
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="25"} 49538
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="26"} 51833
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="26"} 49544
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="27"} 44996
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="27"} 49587
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="28"} 38990
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="28"} 49794
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="29"} 34401
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="29"} 50122
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="30"} 30195
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="30"} 50427
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="31"} 286660
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="31"} 2358425
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 4476608
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 815593
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 6791400
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 853235
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 7478418
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 773235
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 7021213
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 643406
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 5950957
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 470799
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 4722125
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 302514
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 3605626
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 182730
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 2697883
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 116490
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 2008146
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 85422
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 1498168
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 72273
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 1125087
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 66624
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 853180
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 65250
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 653855
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 65514
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 505382
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 66674
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 395248
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 68275
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 311543
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 69392
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 247324
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 69429
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 198730
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 69505
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 161045
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 69345
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 130775
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 68863
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 107813
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 68159
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 89200
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 67718
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 74413
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 67188
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 62751
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 67234
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 52716
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 67165
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 44943
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 67431
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 38343
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 67752
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 33035
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 68202
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 28458
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 68542
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 24796
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 68805
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 237804
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 2973447
 
 # HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
 # TYPE lustre_disk_io_total counter
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="65536"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="65536"} 1 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="131072"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="131072"} 0 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="262144"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="262144"} 3 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="524288"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="524288"} 16 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 51611589 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 7603189 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 5 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="8192"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="8192"} 1 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="16384"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="16384"} 4 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="32768"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="32768"} 5 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="65536"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="65536"} 11 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="131072"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="131072"} 22 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="262144"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="262144"} 52 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="524288"} 0 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="524288"} 104 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 51626985 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 8646007 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="65536"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="65536"} 1
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="131072"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="131072"} 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="262144"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="262144"} 3
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="524288"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="524288"} 16
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 51611589
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 7603189
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 5
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="8192"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="8192"} 1
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="16384"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="16384"} 4
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="32768"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="32768"} 5
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="65536"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="65536"} 11
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="131072"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="131072"} 22
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="262144"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="262144"} 52
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="524288"} 0
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="524288"} 104
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 51626985
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 8646007
 
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped
 # TYPE lustre_drop_bytes_total counter
-lustre_drop_bytes_total 568792 0
+lustre_drop_bytes_total 568792
 
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
-lustre_drop_count_total{nid="0@lo"} 14 0
-lustre_drop_count_total{nid="192.168.5.244@tcp"} 1171 0
+lustre_drop_count_total{nid="0@lo"} 14
+lustre_drop_count_total{nid="192.168.5.244@tcp"} 1171
 
 # HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
 # TYPE lustre_exports_dirty_total counter
-lustre_exports_dirty_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_exports_dirty_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_exports_dirty_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_exports_dirty_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_exports_granted_total Total number of exports that have been marked granted
 # TYPE lustre_exports_granted_total counter
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 161728 0
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 161728 0
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 161728
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 161728
 
 # HELP lustre_exports_pending_total Total number of exports that have been marked pending
 # TYPE lustre_exports_pending_total counter
-lustre_exports_pending_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_exports_pending_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_exports_pending_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_exports_pending_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_exports_total Total number of times the pool has been exported
 # TYPE lustre_exports_total counter
-lustre_exports_total{component="mgt",target="MGS"} 20 0
-lustre_exports_total{component="ost",target="ai400x2-OST0000"} 4 0
-lustre_exports_total{component="ost",target="ai400x2-OST0001"} 4 0
-lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 32 0
+lustre_exports_total{component="mgt",target="MGS"} 20
+lustre_exports_total{component="ost",target="ai400x2-OST0000"} 4
+lustre_exports_total{component="ost",target="ai400x2-OST0001"} 4
+lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 32
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 2026160128 0
-lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437329862656 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 2395312779264 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 1295779098624 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 2026160128
+lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 437329862656
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 2395312779264
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 1295779098624
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge
-lustre_inodes_free{component="mgt",target="MGS"} 130871 0
-lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 289511640 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 274559286 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 274559285 0
+lustre_inodes_free{component="mgt",target="MGS"} 130871
+lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 289511640
+lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 274559286
+lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 274559285
 
 # HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
 # TYPE lustre_inodes_maximum gauge
-lustre_inodes_maximum{component="mgt",target="MGS"} 131072 0
-lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 289887952 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 274726912 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 274726912 0
+lustre_inodes_maximum{component="mgt",target="MGS"} 131072
+lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 289887952
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 274726912
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 274726912
 
 # HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
 # TYPE lustre_io_time_milliseconds_total counter
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 50373687 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 4280167 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 743242 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 205671 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 341963 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 195378 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 76845 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 390020 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 47197 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 999520 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 19272 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 813558 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 8003 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 367069 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 897 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 331943 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 483 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 19794 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="512"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="512"} 89 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 50547465 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 4239888 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 652348 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 237528 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 282920 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 302063 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 66349 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 612273 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 48972 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 1224719 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 19180 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 1117327 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 7925 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 463838 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 1391 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 416479 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 435 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 32022 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="512"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="512"} 73 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 50373687
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 4280167
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 743242
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 205671
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 341963
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 195378
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 76845
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 390020
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 47197
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 999520
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 19272
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 813558
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 8003
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 367069
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 897
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 331943
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 483
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 19794
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="512"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="512"} 89
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 50547465
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 4239888
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 652348
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 237528
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 282920
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 302063
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 66349
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 612273
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 48972
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 1224719
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 19180
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 1117327
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 7925
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 463838
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 1391
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 416479
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 435
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 32022
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="512"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="512"} 73
 
 # HELP lustre_lock_contended_total Number of contended locks
 # TYPE lustre_lock_contended_total counter
-lustre_lock_contended_total{component="mdt",target="ai400x2-MDT0000"} 32 0
-lustre_lock_contended_total{component="ost",target="ai400x2-OST0000"} 32 0
-lustre_lock_contended_total{component="ost",target="ai400x2-OST0001"} 32 0
+lustre_lock_contended_total{component="mdt",target="ai400x2-MDT0000"} 32
+lustre_lock_contended_total{component="ost",target="ai400x2-OST0000"} 32
+lustre_lock_contended_total{component="ost",target="ai400x2-OST0001"} 32
 
 # HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended
 # TYPE lustre_lock_contention_seconds_total counter
-lustre_lock_contention_seconds_total{component="mdt",target="ai400x2-MDT0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0001"} 2 0
+lustre_lock_contention_seconds_total{component="mdt",target="ai400x2-MDT0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0001"} 2
 
 # HELP lustre_lock_count_total Number of locks
 # TYPE lustre_lock_count_total counter
-lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 6 0
-lustre_lock_count_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_lock_count_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 6
+lustre_lock_count_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_lock_count_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_lock_timeout_total Number of lock timeouts
 # TYPE lustre_lock_timeout_total counter
-lustre_lock_timeout_total{component="mdt",target="ai400x2-MDT0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_lock_timeout_total{component="mdt",target="ai400x2-MDT0000"} 0
+lustre_lock_timeout_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_lock_timeout_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
 # TYPE lustre_pages_per_bulk_rw_total counter
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 1 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 3 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 16 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 51611589 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 7603189 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 5 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 1 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 4 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 5 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 11 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 20 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 53 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 104 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 51626985 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 8646007 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 1
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 3
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 16
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 51611589
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 7603189
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 5
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 1
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 4
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 5
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 11
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 20
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 53
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 104
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 51626985
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 8646007
 
 # HELP lustre_read_bytes_total The total number of bytes that have been read.
 # TYPE lustre_read_bytes_total counter
-lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0000"} 54118673547264 0
-lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0001"} 54134817423360 0
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0000"} 54118673547264
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0001"} 54134817423360
 
 # HELP lustre_read_maximum_size_bytes The maximum read size in bytes.
 # TYPE lustre_read_maximum_size_bytes gauge
-lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 1048576 0
-lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 1048576 0
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 1048576
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 1048576
 
 # HELP lustre_read_minimum_size_bytes The minimum read size in bytes.
 # TYPE lustre_read_minimum_size_bytes gauge
-lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 1048576 0
-lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 1048576 0
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 1048576
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 1048576
 
 # HELP lustre_read_samples_total Total number of reads that have been recorded.
 # TYPE lustre_read_samples_total counter
-lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 51611589 0
-lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0001"} 51626985 0
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 51611589
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0001"} 51626985
 
 # HELP lustre_receive_bytes_total Total number of bytes that have been received
 # TYPE lustre_receive_bytes_total counter
-lustre_receive_bytes_total 17112204583664 0
+lustre_receive_bytes_total 17112204583664
 
 # HELP lustre_receive_count_total Total number of messages that have been received
 # TYPE lustre_receive_count_total counter
-lustre_receive_count_total{nid="0@lo"} 3298867 0
-lustre_receive_count_total{nid="192.168.5.244@tcp"} 269560217 0
+lustre_receive_count_total{nid="0@lo"} 3298867
+lustre_receive_count_total{nid="192.168.5.244@tcp"} 269560217
 
 # HELP lustre_send_bytes_total Total number of bytes that have been sent
 # TYPE lustre_send_bytes_total counter
-lustre_send_bytes_total 109811678162896 0
+lustre_send_bytes_total 109811678162896
 
 # HELP lustre_send_count_total Total number of messages that have been sent
 # TYPE lustre_send_count_total counter
-lustre_send_count_total{nid="0@lo"} 3298881 0
-lustre_send_count_total{nid="192.168.5.244@tcp"} 269295337 0
+lustre_send_count_total{nid="0@lo"} 3298881
+lustre_send_count_total{nid="192.168.5.244@tcp"} 269295337
 
 # HELP lustre_stats_total Number of operations the filesystem has performed.
 # TYPE lustre_stats_total counter
-lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 34027 0
-lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 4928393 0
-lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 32663 0
-lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 216662 0
-lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 1 0
-lustre_stats_total{component="mdt",operation="rmdir",target="ai400x2-MDT0000"} 16 0
-lustre_stats_total{component="mdt",operation="rename",target="ai400x2-MDT0000"} 16000 0
-lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 6805232 0
-lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 14202 0
-lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 256044 0
-lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 235719 0
-lustre_stats_total{component="mdt",operation="crossdir_rename",target="ai400x2-MDT0000"} 16000 0
+lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 34027
+lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 4928393
+lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 32663
+lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 216662
+lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 1
+lustre_stats_total{component="mdt",operation="rmdir",target="ai400x2-MDT0000"} 16
+lustre_stats_total{component="mdt",operation="rename",target="ai400x2-MDT0000"} 16000
+lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 6805232
+lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 14202
+lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 256044
+lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 235719
+lustre_stats_total{component="mdt",operation="crossdir_rename",target="ai400x2-MDT0000"} 16000
 
 # HELP lustre_write_bytes_total The total number of bytes that have been written.
 # TYPE lustre_write_bytes_total counter
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 7972519944192 0
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 9065997639680 0
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 7972519944192
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 9065997639680
 
 # HELP lustre_write_maximum_size_bytes The maximum write size in bytes.
 # TYPE lustre_write_maximum_size_bytes gauge
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 1048576 0
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 1048576 0
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 1048576
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 1048576
 
 # HELP lustre_write_minimum_size_bytes The minimum write size in bytes.
 # TYPE lustre_write_minimum_size_bytes gauge
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 61440 0
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 4096 0
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 61440
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 4096
 
 # HELP lustre_write_samples_total Total number of writes that have been recorded.
 # TYPE lustre_write_samples_total counter
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 7603209 0
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 8646209 0
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 7603209
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 8646209
 

--- a/src/snapshots/lustrefs_exporter__tests__stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__stats.snap
@@ -4,620 +4,620 @@ expression: x
 ---
 # HELP lustre_available_kilobytes Number of kilobytes readily available in the pool
 # TYPE lustre_available_kilobytes gauge
-lustre_available_kilobytes{component="mgt",target="MGS"} 1873772 0
-lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 419917436 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 34187914484 0
-lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 34188706564 0
+lustre_available_kilobytes{component="mgt",target="MGS"} 1873772
+lustre_available_kilobytes{component="mdt",target="ai400x2-MDT0000"} 419917436
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0000"} 34187914484
+lustre_available_kilobytes{component="ost",target="ai400x2-OST0001"} 34188706564
 
 # HELP lustre_capacity_kilobytes Capacity of the pool in kilobytes
 # TYPE lustre_capacity_kilobytes gauge
-lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036 0
-lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427170984 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 34750424936 0
-lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 34750424936 0
+lustre_capacity_kilobytes{component="mgt",target="MGS"} 1980036
+lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427170984
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 34750424936
+lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 34750424936
 
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1 0
-lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1 0
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1
+lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1
 
 # HELP lustre_dio_frags Current disk IO fragmentation for the given size.
 # TYPE lustre_dio_frags gauge
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9292607 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 4076945 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 3669 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 3434 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 2 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 11 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 2509 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 6 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 2041 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 55768 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 38711 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9254837 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 4080923 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 3808 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 3599 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 14 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 2603 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 7 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 2055 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 0 0
-lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 57294 0
-lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 39039 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9292607
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 4076945
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 3669
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 3434
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 2
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 11
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 2509
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 6
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 2041
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 55768
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 38711
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9254837
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 4080923
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 3808
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 3599
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 14
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 2603
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 7
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 2055
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 0
+lustre_dio_frags{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 57294
+lustre_dio_frags{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 39039
 
 # HELP lustre_discontiguous_blocks_total 
 # TYPE lustre_discontiguous_blocks_total counter
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9292664 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4072612 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 42047 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 28493 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 17352 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 21665 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 687 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 137 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 27 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 13 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 5 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 1 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9254895 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4076814 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 41231 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 28934 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 19835 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 21641 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 635 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 146 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 33 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 12 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 3 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 0 0
-lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 1 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9292664
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4072612
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 42047
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 28493
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 17352
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 21665
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 687
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 137
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 27
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 13
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 5
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 1
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9254895
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4076814
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 41231
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 28934
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 19835
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 21641
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 635
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 146
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 33
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 12
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 3
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 0
+lustre_discontiguous_blocks_total{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 1
 
 # HELP lustre_discontiguous_pages_total Total number of logical discontinuities per RPC.
 # TYPE lustre_discontiguous_pages_total counter
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9351652 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4114231 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 409 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 9407 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 2 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 2 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9315526 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4118794 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 435 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 9423 0
-lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0 0
-lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 2 0
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="0"} 9351652
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="0"} 4114231
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 409
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 9407
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 2
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 2
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="0"} 9315526
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="0"} 4118794
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 435
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 9423
+lustre_discontiguous_pages_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 0
+lustre_discontiguous_pages_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 2
 
 # HELP lustre_disk_io Current number of I/O operations that are processing during the snapshot.
 # TYPE lustre_disk_io gauge
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 2499387 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 1187036 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 1883945 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 793707 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 1493683 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 503920 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 1058167 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 395381 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 704804 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 288275 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 495027 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 197769 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 356780 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 132864 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 256413 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 89052 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="9"} 181632 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="9"} 58501 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="10"} 123818 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="10"} 26704 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="11"} 90035 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="11"} 14119 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="12"} 68887 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="12"} 8829 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="13"} 55465 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="13"} 6550 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="14"} 45232 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="14"} 5547 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="15"} 38000 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="15"} 5383 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 31971 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 5481 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="17"} 25211 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="17"} 6177 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="18"} 21467 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="18"} 6767 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="19"} 18780 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="19"} 8074 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="20"} 16625 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="20"} 9646 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="21"} 15098 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="21"} 12313 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="22"} 13849 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="22"} 15267 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="23"} 13017 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="23"} 19877 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="24"} 12337 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="24"} 24453 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="25"} 11413 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="25"} 30315 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="26"} 11028 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="26"} 34324 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="27"} 10704 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="27"} 37750 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="28"} 10471 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="28"} 38776 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="29"} 10297 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="29"} 38871 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="30"} 10119 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="30"} 36556 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="31"} 162513 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="31"} 377499 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 2488039 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 1185285 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 1873744 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 787309 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1490244 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 498673 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 1058749 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 395423 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 704439 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 291932 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 495012 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 201902 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 357583 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 137081 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 255910 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 91340 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 181672 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 59739 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 122401 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 27549 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 88149 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 14513 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 67154 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 9077 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 53823 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 6688 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 44023 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 5725 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 37170 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 5530 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 31368 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 5664 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 24929 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 6440 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 21347 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 7087 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 18674 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 8465 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 16527 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 10044 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 15156 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 12647 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 14051 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 15863 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 13243 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 20105 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 12577 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 24737 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 11661 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 30564 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 11371 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 34765 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 11019 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 37755 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 10843 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 38708 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 10656 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 38610 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 10512 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 36144 0
-lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 168860 0
-lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 377811 0
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 2499387
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 1187036
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 1883945
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 793707
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="3"} 1493683
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="3"} 503920
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 1058167
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 395381
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="5"} 704804
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="5"} 288275
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="6"} 495027
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="6"} 197769
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="7"} 356780
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="7"} 132864
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 256413
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 89052
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="9"} 181632
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="9"} 58501
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="10"} 123818
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="10"} 26704
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="11"} 90035
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="11"} 14119
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="12"} 68887
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="12"} 8829
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="13"} 55465
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="13"} 6550
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="14"} 45232
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="14"} 5547
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="15"} 38000
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="15"} 5383
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 31971
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 5481
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="17"} 25211
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="17"} 6177
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="18"} 21467
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="18"} 6767
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="19"} 18780
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="19"} 8074
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="20"} 16625
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="20"} 9646
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="21"} 15098
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="21"} 12313
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="22"} 13849
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="22"} 15267
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="23"} 13017
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="23"} 19877
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="24"} 12337
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="24"} 24453
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="25"} 11413
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="25"} 30315
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="26"} 11028
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="26"} 34324
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="27"} 10704
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="27"} 37750
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="28"} 10471
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="28"} 38776
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="29"} 10297
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="29"} 38871
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="30"} 10119
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="30"} 36556
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0000",size="31"} 162513
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0000",size="31"} 377499
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 2488039
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 1185285
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 1873744
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 787309
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="3"} 1490244
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="3"} 498673
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 1058749
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 395423
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="5"} 704439
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="5"} 291932
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="6"} 495012
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="6"} 201902
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="7"} 357583
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="7"} 137081
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 255910
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 91340
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="9"} 181672
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="9"} 59739
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="10"} 122401
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="10"} 27549
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="11"} 88149
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="11"} 14513
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="12"} 67154
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="12"} 9077
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="13"} 53823
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="13"} 6688
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="14"} 44023
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="14"} 5725
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="15"} 37170
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="15"} 5530
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 31368
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 5664
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="17"} 24929
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="17"} 6440
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="18"} 21347
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="18"} 7087
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="19"} 18674
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="19"} 8465
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="20"} 16527
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="20"} 10044
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="21"} 15156
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="21"} 12647
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="22"} 14051
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="22"} 15863
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="23"} 13243
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="23"} 20105
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="24"} 12577
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="24"} 24737
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="25"} 11661
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="25"} 30564
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="26"} 11371
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="26"} 34765
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="27"} 11019
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="27"} 37755
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="28"} 10843
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="28"} 38708
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="29"} 10656
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="29"} 38610
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="30"} 10512
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="30"} 36144
+lustre_disk_io{component="ost",operation="read",target="ai400x2-OST0001",size="31"} 168860
+lustre_disk_io{component="ost",operation="write",target="ai400x2-OST0001",size="31"} 377811
 
 # HELP lustre_disk_io_total Total number of operations the filesystem has performed for the given size.
 # TYPE lustre_disk_io_total counter
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 48747 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 9253 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="8192"} 808 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="8192"} 24 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="16384"} 342 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="16384"} 144 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="32768"} 819 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="32768"} 129 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="65536"} 1394 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="65536"} 344 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="131072"} 3731 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="131072"} 777 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="262144"} 5397 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="262144"} 1152 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="524288"} 8031 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="524288"} 1759 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 9230582 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 4063409 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="2097152"} 446324 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="2097152"} 338792 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 50197 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 9280 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="8192"} 710 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="8192"} 28 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="16384"} 281 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="16384"} 125 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="32768"} 867 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="32768"} 148 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="65536"} 1407 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="65536"} 329 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="131072"} 3430 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="131072"} 741 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="262144"} 5639 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="262144"} 1216 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="524288"} 7966 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="524288"} 1763 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 9191867 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 4067353 0
-lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="2097152"} 458542 0
-lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="2097152"} 342192 0
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 48747
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 9253
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="8192"} 808
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="8192"} 24
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="16384"} 342
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="16384"} 144
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="32768"} 819
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="32768"} 129
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="65536"} 1394
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="65536"} 344
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="131072"} 3731
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="131072"} 777
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="262144"} 5397
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="262144"} 1152
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="524288"} 8031
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="524288"} 1759
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="1048576"} 9230582
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="1048576"} 4063409
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0000",size="2097152"} 446324
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0000",size="2097152"} 338792
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 50197
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 9280
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="8192"} 710
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="8192"} 28
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="16384"} 281
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="16384"} 125
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="32768"} 867
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="32768"} 148
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="65536"} 1407
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="65536"} 329
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="131072"} 3430
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="131072"} 741
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="262144"} 5639
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="262144"} 1216
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="524288"} 7966
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="524288"} 1763
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="1048576"} 9191867
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="1048576"} 4067353
+lustre_disk_io_total{component="ost",operation="read",target="ai400x2-OST0001",size="2097152"} 458542
+lustre_disk_io_total{component="ost",operation="write",target="ai400x2-OST0001",size="2097152"} 342192
 
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped
 # TYPE lustre_drop_bytes_total counter
-lustre_drop_bytes_total 0 0
+lustre_drop_bytes_total 0
 
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
-lustre_drop_count_total{nid="0@lo"} 0 0
-lustre_drop_count_total{nid="172.16.240.133@o2ib"} 0 0
-lustre_drop_count_total{nid="172.16.241.133@o2ib"} 0 0
+lustre_drop_count_total{nid="0@lo"} 0
+lustre_drop_count_total{nid="172.16.240.133@o2ib"} 0
+lustre_drop_count_total{nid="172.16.241.133@o2ib"} 0
 
 # HELP lustre_exports_dirty_total Total number of exports that have been marked dirty
 # TYPE lustre_exports_dirty_total counter
-lustre_exports_dirty_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_exports_dirty_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_exports_dirty_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_exports_dirty_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_exports_granted_total Total number of exports that have been marked granted
 # TYPE lustre_exports_granted_total counter
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 143424 0
-lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 143424 0
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0000"} 143424
+lustre_exports_granted_total{component="ost",target="ai400x2-OST0001"} 143424
 
 # HELP lustre_exports_pending_total Total number of exports that have been marked pending
 # TYPE lustre_exports_pending_total counter
-lustre_exports_pending_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_exports_pending_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_exports_pending_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_exports_pending_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_exports_total Total number of times the pool has been exported
 # TYPE lustre_exports_total counter
-lustre_exports_total{component="mgt",target="MGS"} 6 0
-lustre_exports_total{component="ost",target="ai400x2-OST0000"} 4 0
-lustre_exports_total{component="ost",target="ai400x2-OST0001"} 4 0
-lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 16 0
+lustre_exports_total{component="mgt",target="MGS"} 6
+lustre_exports_total{component="ost",target="ai400x2-OST0000"} 4
+lustre_exports_total{component="ost",target="ai400x2-OST0001"} 4
+lustre_exports_total{component="mdt",target="ai400x2-MDT0000"} 16
 
 # HELP lustre_free_kilobytes Number of kilobytes allocated to the pool
 # TYPE lustre_free_kilobytes gauge
-lustre_free_kilobytes{component="mgt",target="MGS"} 1978628 0
-lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427164896 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 34539581312 0
-lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 34540373392 0
+lustre_free_kilobytes{component="mgt",target="MGS"} 1978628
+lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427164896
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0000"} 34539581312
+lustre_free_kilobytes{component="ost",target="ai400x2-OST0001"} 34540373392
 
 # HELP lustre_inodes_free The number of inodes (objects) available
 # TYPE lustre_inodes_free gauge
-lustre_inodes_free{component="mgt",target="MGS"} 130871 0
-lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 289887431 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 274725135 0
-lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 274725134 0
+lustre_inodes_free{component="mgt",target="MGS"} 130871
+lustre_inodes_free{component="mdt",target="ai400x2-MDT0000"} 289887431
+lustre_inodes_free{component="ost",target="ai400x2-OST0000"} 274725135
+lustre_inodes_free{component="ost",target="ai400x2-OST0001"} 274725134
 
 # HELP lustre_inodes_maximum The maximum number of inodes (objects) the filesystem can hold
 # TYPE lustre_inodes_maximum gauge
-lustre_inodes_maximum{component="mgt",target="MGS"} 131072 0
-lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 289887952 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 274726912 0
-lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 274726912 0
+lustre_inodes_maximum{component="mgt",target="MGS"} 131072
+lustre_inodes_maximum{component="mdt",target="ai400x2-MDT0000"} 289887952
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0000"} 274726912
+lustre_inodes_maximum{component="ost",target="ai400x2-OST0001"} 274726912
 
 # HELP lustre_io_time_milliseconds_total Total time in milliseconds the filesystem has spent processing various object sizes.
 # TYPE lustre_io_time_milliseconds_total counter
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9244557 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 3616861 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 45925 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 83848 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 30611 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 314948 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 26141 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 49922 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 4808 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 51585 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 14 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 6394 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 6 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 82 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 1 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 0 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9207507 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 3621675 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 45907 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 83387 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 31151 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 314557 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 26619 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 50234 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 4762 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 52033 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 9 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 6238 0
-lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 6 0
-lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 95 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 9244557
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 3616861
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 45925
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 83848
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 30611
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 314948
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 26141
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 49922
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 4808
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 51585
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 14
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 6394
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 6
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 82
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 1
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 0
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 9207507
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 3621675
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 45907
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 83387
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 31151
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 314557
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 26619
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 50234
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 4762
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 52033
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 9
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 6238
+lustre_io_time_milliseconds_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 6
+lustre_io_time_milliseconds_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 95
 
 # HELP lustre_ldlm_canceld_stats Gives information about LDLM Canceld service.
 # TYPE lustre_ldlm_canceld_stats counter
-lustre_ldlm_canceld_stats{operation="req_waittime"} 30049 0
-lustre_ldlm_canceld_stats{operation="req_qdepth"} 30049 0
-lustre_ldlm_canceld_stats{operation="req_active"} 30049 0
-lustre_ldlm_canceld_stats{operation="req_timeout"} 30049 0
-lustre_ldlm_canceld_stats{operation="reqbuf_avail"} 61601 0
-lustre_ldlm_canceld_stats{operation="ldlm_cancel"} 30049 0
+lustre_ldlm_canceld_stats{operation="req_waittime"} 30049
+lustre_ldlm_canceld_stats{operation="req_qdepth"} 30049
+lustre_ldlm_canceld_stats{operation="req_active"} 30049
+lustre_ldlm_canceld_stats{operation="req_timeout"} 30049
+lustre_ldlm_canceld_stats{operation="reqbuf_avail"} 61601
+lustre_ldlm_canceld_stats{operation="ldlm_cancel"} 30049
 
 # HELP lustre_ldlm_cbd_stats Gives information about LDLM Callback service.
 # TYPE lustre_ldlm_cbd_stats counter
-lustre_ldlm_cbd_stats{operation="req_waittime"} 79 0
-lustre_ldlm_cbd_stats{operation="req_qdepth"} 79 0
-lustre_ldlm_cbd_stats{operation="req_active"} 79 0
-lustre_ldlm_cbd_stats{operation="req_timeout"} 79 0
-lustre_ldlm_cbd_stats{operation="reqbuf_avail"} 177 0
-lustre_ldlm_cbd_stats{operation="ldlm_bl_callback"} 79 0
+lustre_ldlm_cbd_stats{operation="req_waittime"} 79
+lustre_ldlm_cbd_stats{operation="req_qdepth"} 79
+lustre_ldlm_cbd_stats{operation="req_active"} 79
+lustre_ldlm_cbd_stats{operation="req_timeout"} 79
+lustre_ldlm_cbd_stats{operation="reqbuf_avail"} 177
+lustre_ldlm_cbd_stats{operation="ldlm_bl_callback"} 79
 
 # HELP lustre_lock_contended_total Number of contended locks
 # TYPE lustre_lock_contended_total counter
-lustre_lock_contended_total{component="mdt",target="ai400x2-MDT0000"} 32 0
-lustre_lock_contended_total{component="ost",target="ai400x2-OST0000"} 32 0
-lustre_lock_contended_total{component="ost",target="ai400x2-OST0001"} 32 0
+lustre_lock_contended_total{component="mdt",target="ai400x2-MDT0000"} 32
+lustre_lock_contended_total{component="ost",target="ai400x2-OST0000"} 32
+lustre_lock_contended_total{component="ost",target="ai400x2-OST0001"} 32
 
 # HELP lustre_lock_contention_seconds_total Time in seconds during which locks were contended
 # TYPE lustre_lock_contention_seconds_total counter
-lustre_lock_contention_seconds_total{component="mdt",target="ai400x2-MDT0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0000"} 2 0
-lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0001"} 2 0
+lustre_lock_contention_seconds_total{component="mdt",target="ai400x2-MDT0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0000"} 2
+lustre_lock_contention_seconds_total{component="ost",target="ai400x2-OST0001"} 2
 
 # HELP lustre_lock_count_total Number of locks
 # TYPE lustre_lock_count_total counter
-lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 2 0
-lustre_lock_count_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_lock_count_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_lock_count_total{component="mdt",target="ai400x2-MDT0000"} 2
+lustre_lock_count_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_lock_count_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_lock_timeout_total Number of lock timeouts
 # TYPE lustre_lock_timeout_total counter
-lustre_lock_timeout_total{component="mdt",target="ai400x2-MDT0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="ai400x2-OST0000"} 0 0
-lustre_lock_timeout_total{component="ost",target="ai400x2-OST0001"} 0 0
+lustre_lock_timeout_total{component="mdt",target="ai400x2-MDT0000"} 0
+lustre_lock_timeout_total{component="ost",target="ai400x2-OST0000"} 0
+lustre_lock_timeout_total{component="ost",target="ai400x2-OST0001"} 0
 
 # HELP lustre_oss_ost_create_stats OSS ost_create stats
 # TYPE lustre_oss_ost_create_stats gauge
-lustre_oss_ost_create_stats{operation="req_waittime",units="usec"} 244994 0
-lustre_oss_ost_create_stats{operation="req_qdepth",units="reqs"} 244994 0
-lustre_oss_ost_create_stats{operation="req_active",units="reqs"} 244994 0
-lustre_oss_ost_create_stats{operation="req_timeout",units="sec"} 244994 0
-lustre_oss_ost_create_stats{operation="reqbuf_avail",units="bufs"} 507392 0
-lustre_oss_ost_create_stats{operation="ost_statfs",units="usec"} 244994 0
+lustre_oss_ost_create_stats{operation="req_waittime",units="usec"} 244994
+lustre_oss_ost_create_stats{operation="req_qdepth",units="reqs"} 244994
+lustre_oss_ost_create_stats{operation="req_active",units="reqs"} 244994
+lustre_oss_ost_create_stats{operation="req_timeout",units="sec"} 244994
+lustre_oss_ost_create_stats{operation="reqbuf_avail",units="bufs"} 507392
+lustre_oss_ost_create_stats{operation="ost_statfs",units="usec"} 244994
 
 # HELP lustre_oss_ost_io_stats OSS ost_io stats
 # TYPE lustre_oss_ost_io_stats gauge
-lustre_oss_ost_io_stats{operation="req_waittime",units="usec"} 26901856 0
-lustre_oss_ost_io_stats{operation="req_qdepth",units="reqs"} 26901856 0
-lustre_oss_ost_io_stats{operation="req_active",units="reqs"} 26901856 0
-lustre_oss_ost_io_stats{operation="req_timeout",units="sec"} 26901856 0
-lustre_oss_ost_io_stats{operation="reqbuf_avail",units="bufs"} 55114862 0
-lustre_oss_ost_io_stats{operation="ost_read",units="usec"} 18668007 0
-lustre_oss_ost_io_stats{operation="ost_write",units="usec"} 8233790 0
-lustre_oss_ost_io_stats{operation="ost_punch",units="usec"} 59 0
+lustre_oss_ost_io_stats{operation="req_waittime",units="usec"} 26901856
+lustre_oss_ost_io_stats{operation="req_qdepth",units="reqs"} 26901856
+lustre_oss_ost_io_stats{operation="req_active",units="reqs"} 26901856
+lustre_oss_ost_io_stats{operation="req_timeout",units="sec"} 26901856
+lustre_oss_ost_io_stats{operation="reqbuf_avail",units="bufs"} 55114862
+lustre_oss_ost_io_stats{operation="ost_read",units="usec"} 18668007
+lustre_oss_ost_io_stats{operation="ost_write",units="usec"} 8233790
+lustre_oss_ost_io_stats{operation="ost_punch",units="usec"} 59
 
 # HELP lustre_oss_ost_stats OSS ost stats
 # TYPE lustre_oss_ost_stats gauge
-lustre_oss_ost_stats{operation="req_waittime",units="usec"} 77655 0
-lustre_oss_ost_stats{operation="req_qdepth",units="reqs"} 77655 0
-lustre_oss_ost_stats{operation="req_active",units="reqs"} 77655 0
-lustre_oss_ost_stats{operation="req_timeout",units="sec"} 77655 0
-lustre_oss_ost_stats{operation="reqbuf_avail",units="bufs"} 157527 0
-lustre_oss_ost_stats{operation="ldlm_glimpse_enqueue",units="reqs"} 42486 0
-lustre_oss_ost_stats{operation="ldlm_extent_enqueue",units="reqs"} 17980 0
-lustre_oss_ost_stats{operation="ost_create",units="usec"} 578 0
-lustre_oss_ost_stats{operation="ost_destroy",units="usec"} 15361 0
-lustre_oss_ost_stats{operation="ost_get_info",units="usec"} 8 0
-lustre_oss_ost_stats{operation="ost_connect",units="usec"} 68 0
-lustre_oss_ost_stats{operation="ost_disconnect",units="usec"} 48 0
-lustre_oss_ost_stats{operation="ost_sync",units="usec"} 56 0
-lustre_oss_ost_stats{operation="ost_set_info",units="usec"} 20 0
-lustre_oss_ost_stats{operation="obd_ping",units="usec"} 1050 0
+lustre_oss_ost_stats{operation="req_waittime",units="usec"} 77655
+lustre_oss_ost_stats{operation="req_qdepth",units="reqs"} 77655
+lustre_oss_ost_stats{operation="req_active",units="reqs"} 77655
+lustre_oss_ost_stats{operation="req_timeout",units="sec"} 77655
+lustre_oss_ost_stats{operation="reqbuf_avail",units="bufs"} 157527
+lustre_oss_ost_stats{operation="ldlm_glimpse_enqueue",units="reqs"} 42486
+lustre_oss_ost_stats{operation="ldlm_extent_enqueue",units="reqs"} 17980
+lustre_oss_ost_stats{operation="ost_create",units="usec"} 578
+lustre_oss_ost_stats{operation="ost_destroy",units="usec"} 15361
+lustre_oss_ost_stats{operation="ost_get_info",units="usec"} 8
+lustre_oss_ost_stats{operation="ost_connect",units="usec"} 68
+lustre_oss_ost_stats{operation="ost_disconnect",units="usec"} 48
+lustre_oss_ost_stats{operation="ost_sync",units="usec"} 56
+lustre_oss_ost_stats{operation="ost_set_info",units="usec"} 20
+lustre_oss_ost_stats{operation="obd_ping",units="usec"} 1050
 
 # HELP lustre_pages_per_bulk_rw_total Total number of pages per block RPC.
 # TYPE lustre_pages_per_bulk_rw_total counter
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 45221 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 192 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 807 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 67 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 341 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 262 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 818 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 262 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 1382 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 728 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 3718 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 1548 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 5363 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 2295 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 7996 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 3506 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 9230582 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 4068108 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1024"} 50 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1024"} 3411 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2048"} 11 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2048"} 2509 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 55774 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 40752 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 46495 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 208 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 709 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 85 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 281 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 248 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 867 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 281 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 1396 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 702 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 3421 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 1478 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 5613 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 2418 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 7951 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 3519 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 9191867 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 4072014 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="512"} 0 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1024"} 46 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1024"} 3569 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2048"} 14 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2048"} 2603 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 57301 0
-lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 41094 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1"} 45221
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1"} 192
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2"} 807
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2"} 67
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4"} 341
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4"} 262
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="8"} 818
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="8"} 262
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="16"} 1382
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="16"} 728
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="32"} 3718
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="32"} 1548
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="64"} 5363
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="64"} 2295
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="128"} 7996
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="128"} 3506
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="256"} 9230582
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="256"} 4068108
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="1024"} 50
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="1024"} 3411
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="2048"} 11
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="2048"} 2509
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0000",size="4096"} 55774
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0000",size="4096"} 40752
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1"} 46495
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1"} 208
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2"} 709
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2"} 85
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4"} 281
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4"} 248
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="8"} 867
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="8"} 281
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="16"} 1396
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="16"} 702
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="32"} 3421
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="32"} 1478
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="64"} 5613
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="64"} 2418
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="128"} 7951
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="128"} 3519
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="256"} 9191867
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="256"} 4072014
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="512"} 0
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="1024"} 46
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="1024"} 3569
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="2048"} 14
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="2048"} 2603
+lustre_pages_per_bulk_rw_total{component="ost",operation="read",target="ai400x2-OST0001",size="4096"} 57301
+lustre_pages_per_bulk_rw_total{component="ost",operation="write",target="ai400x2-OST0001",size="4096"} 41094
 
 # HELP lustre_read_bytes_total The total number of bytes that have been read.
 # TYPE lustre_read_bytes_total counter
-lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0000"} 10614117224448 0
-lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0001"} 10599265554432 0
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0000"} 10614117224448
+lustre_read_bytes_total{component="ost",operation="read",target="ai400x2-OST0001"} 10599265554432
 
 # HELP lustre_read_maximum_size_bytes The maximum read size in bytes.
 # TYPE lustre_read_maximum_size_bytes gauge
-lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 16777216 0
-lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 16777216 0
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 16777216
+lustre_read_maximum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 16777216
 
 # HELP lustre_read_minimum_size_bytes The minimum read size in bytes.
 # TYPE lustre_read_minimum_size_bytes gauge
-lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 4096 0
-lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 4096 0
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0000"} 4096
+lustre_read_minimum_size_bytes{component="ost",operation="read",target="ai400x2-OST0001"} 4096
 
 # HELP lustre_read_samples_total Total number of reads that have been recorded.
 # TYPE lustre_read_samples_total counter
-lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 9352060 0
-lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0001"} 9315947 0
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 9352060
+lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0001"} 9315947
 
 # HELP lustre_receive_bytes_total Total number of bytes that have been received
 # TYPE lustre_receive_bytes_total counter
-lustre_receive_bytes_total 9966973976959 0
+lustre_receive_bytes_total 9966973976959
 
 # HELP lustre_receive_count_total Total number of messages that have been received
 # TYPE lustre_receive_count_total counter
-lustre_receive_count_total{nid="0@lo"} 191882 0
-lustre_receive_count_total{nid="172.16.240.133@o2ib"} 24143352 0
-lustre_receive_count_total{nid="172.16.241.133@o2ib"} 24141806 0
+lustre_receive_count_total{nid="0@lo"} 191882
+lustre_receive_count_total{nid="172.16.240.133@o2ib"} 24143352
+lustre_receive_count_total{nid="172.16.241.133@o2ib"} 24141806
 
 # HELP lustre_send_bytes_total Total number of bytes that have been sent
 # TYPE lustre_send_bytes_total counter
-lustre_send_bytes_total 21225620772816 0
+lustre_send_bytes_total 21225620772816
 
 # HELP lustre_send_count_total Total number of messages that have been sent
 # TYPE lustre_send_count_total counter
-lustre_send_count_total{nid="0@lo"} 191882 0
-lustre_send_count_total{nid="172.16.240.133@o2ib"} 28893723 0
-lustre_send_count_total{nid="172.16.241.133@o2ib"} 28892480 0
+lustre_send_count_total{nid="0@lo"} 191882
+lustre_send_count_total{nid="172.16.240.133@o2ib"} 28893723
+lustre_send_count_total{nid="172.16.241.133@o2ib"} 28892480
 
 # HELP lustre_stats_total Number of operations the filesystem has performed.
 # TYPE lustre_stats_total counter
-lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 232 0
-lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 7632 0
-lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 228 0
-lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 3 0
-lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 6 0
-lustre_stats_total{component="mdt",operation="rmdir",target="ai400x2-MDT0000"} 4 0
-lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 9464 0
-lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 228 0
-lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 3591 0
-lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 91893 0
-lustre_stats_total{component="mdt",operation="sync",target="ai400x2-MDT0000"} 224 0
+lustre_stats_total{component="mdt",operation="open",target="ai400x2-MDT0000"} 232
+lustre_stats_total{component="mdt",operation="close",target="ai400x2-MDT0000"} 7632
+lustre_stats_total{component="mdt",operation="mknod",target="ai400x2-MDT0000"} 228
+lustre_stats_total{component="mdt",operation="unlink",target="ai400x2-MDT0000"} 3
+lustre_stats_total{component="mdt",operation="mkdir",target="ai400x2-MDT0000"} 6
+lustre_stats_total{component="mdt",operation="rmdir",target="ai400x2-MDT0000"} 4
+lustre_stats_total{component="mdt",operation="getattr",target="ai400x2-MDT0000"} 9464
+lustre_stats_total{component="mdt",operation="setattr",target="ai400x2-MDT0000"} 228
+lustre_stats_total{component="mdt",operation="getxattr",target="ai400x2-MDT0000"} 3591
+lustre_stats_total{component="mdt",operation="statfs",target="ai400x2-MDT0000"} 91893
+lustre_stats_total{component="mdt",operation="sync",target="ai400x2-MDT0000"} 224
 
 # HELP lustre_write_bytes_total The total number of bytes that have been written.
 # TYPE lustre_write_bytes_total counter
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 4971114377425 0
-lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 4982409908141 0
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0000"} 4971114377425
+lustre_write_bytes_total{component="ost",operation="write",target="ai400x2-OST0001"} 4982409908141
 
 # HELP lustre_write_maximum_size_bytes The maximum write size in bytes.
 # TYPE lustre_write_maximum_size_bytes gauge
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 16777216 0
-lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 16777216 0
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 16777216
+lustre_write_maximum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 16777216
 
 # HELP lustre_write_minimum_size_bytes The minimum write size in bytes.
 # TYPE lustre_write_minimum_size_bytes gauge
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 183 0
-lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 183 0
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0000"} 183
+lustre_write_minimum_size_bytes{component="ost",operation="write",target="ai400x2-OST0001"} 183
 
 # HELP lustre_write_samples_total Total number of writes that have been recorded.
 # TYPE lustre_write_samples_total counter
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 4114603 0
-lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 4119187 0
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0000"} 4114603
+lustre_write_samples_total{component="ost",operation="write",target="ai400x2-OST0001"} 4119187
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, ops::Deref, time::Duration};
+use std::{collections::BTreeMap, ops::Deref};
 
 use crate::{LabelProm, Metric, StatsMapExt};
 use lustre_collector::{Stat, Target, TargetStat};
@@ -50,7 +50,6 @@ pub fn build_ost_stats(
     x: Vec<Stat>,
     target: Target,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     let kind = lustre_collector::TargetVariant::Ost;
     for s in x {
@@ -63,8 +62,7 @@ pub fn build_ost_stats(
                             .with_label("component", kind.to_prom_label())
                             .with_label("operation", "read")
                             .with_label("target", target.deref())
-                            .with_value(s.samples)
-                            .with_timestamp(time.as_millis()),
+                            .with_value(s.samples),
                     );
                 s.min.map(|v| {
                     stats_map
@@ -74,8 +72,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "read")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
                 s.max.map(|v| {
@@ -86,8 +83,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "read")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
                 s.sum.map(|v| {
@@ -98,8 +94,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "read")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
             }
@@ -111,8 +106,7 @@ pub fn build_ost_stats(
                             .with_label("component", kind.to_prom_label())
                             .with_label("operation", "write")
                             .with_label("target", target.deref())
-                            .with_value(s.samples)
-                            .with_timestamp(time.as_millis()),
+                            .with_value(s.samples),
                     );
                 s.min.map(|v| {
                     stats_map
@@ -122,8 +116,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "write")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
                 s.max.map(|v| {
@@ -134,8 +127,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "write")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
                 s.sum.map(|v| {
@@ -146,8 +138,7 @@ pub fn build_ost_stats(
                                 .with_label("component", kind.to_prom_label())
                                 .with_label("operation", "write")
                                 .with_label("target", target.deref())
-                                .with_value(v)
-                                .with_timestamp(time.as_millis()),
+                                .with_value(v),
                         )
                 });
             }
@@ -168,7 +159,6 @@ pub fn build_mdt_stats(
     x: Vec<Stat>,
     target: Target,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     let kind = lustre_collector::TargetVariant::Mdt;
     for s in x {
@@ -179,8 +169,7 @@ pub fn build_mdt_stats(
                     .with_label("component", kind.to_prom_label())
                     .with_label("operation", s.name.deref())
                     .with_label("target", target.deref())
-                    .with_value(s.samples)
-                    .with_timestamp(time.as_millis()),
+                    .with_value(s.samples),
             );
     }
 }
@@ -188,7 +177,6 @@ pub fn build_mdt_stats(
 pub fn build_stats(
     x: TargetStat<Vec<Stat>>,
     stats_map: &mut BTreeMap<&'static str, PrometheusMetric<'static>>,
-    time: Duration,
 ) {
     let TargetStat {
         kind,
@@ -198,8 +186,8 @@ pub fn build_stats(
     } = x;
 
     match kind {
-        lustre_collector::TargetVariant::Ost => build_ost_stats(value, target, stats_map, time),
+        lustre_collector::TargetVariant::Ost => build_ost_stats(value, target, stats_map),
         lustre_collector::TargetVariant::Mgt => { /*TODO*/ }
-        lustre_collector::TargetVariant::Mdt => build_mdt_stats(value, target, stats_map, time),
+        lustre_collector::TargetVariant::Mdt => build_mdt_stats(value, target, stats_map),
     }
 }


### PR DESCRIPTION
Disable timestmaps in the metrics output as recommended by [Prometheus documentation](https://prometheus.io/docs/instrumenting/writing_exporters/#:~:text=Accordingly%2C%20you%20should%20not%20set%20timestamps%20on%20the%20metrics%20you%20expose%2C%20let%20Prometheus%20take%20care%20of%20that.%20If%20you%20think%20you%20need%20timestamps%2C%20then%20you%20probably%20need%20the%20Pushgateway%20instead)