### PR TITLE
Add POST support to exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,8 +744,7 @@ dependencies = [
 [[package]]
 name = "prometheus_exporter_base"
 version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42dafed8b073871c93f6082ff0fc597dbf26fb58974f0140f2c6a46c9f9f624"
+source = "git+https://github.com/RDruon/prometheus_exporter_base#fc929650c7991afc2e40a1d19bb61924e9b33df4"
 dependencies = [
  "base64 0.13.1",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.2.10"
 lustre_collector = "0.7"
 num-traits = "0.2.14"
 prometheus = "0.13.3"
-prometheus_exporter_base = {version = "1.4.0", features = ["hyper_server"]}
+prometheus_exporter_base = {git = "https://github.com/RDruon/prometheus_exporter_base", features = ["hyper_server"]}
 tokio = {version = "1.27", features = [
   "rt-multi-thread",
   "macros",


### PR DESCRIPTION
Add POST support to the exporter.

This patch is based on a fork of https://github.com/MindFlavor/prometheus_exporter_base to enable `POST` supports. A PR has been opened to include this change in the official crate https://github.com/MindFlavor/prometheus_exporter_base/pull/30

In the meantime, I can transfer the fork to the `whamcloud` org.

With patch
```
[root@node1 ~]# curl -X POST -I http://localhost:32221/metrics
HTTP/1.1 200 OK
content-type: text/plain; version=0.0.4
content-length: 4766
date: Mon, 26 Feb 2024 11:34:08 GMT
[root@node1 ~]# curl -X GET -I http://localhost:32221/metrics
HTTP/1.1 200 OK
content-type: text/plain; version=0.0.4
content-length: 4766
date: Mon, 26 Feb 2024 11:34:12 GMT
```
Without patch (`405 Method Not Allowed`):
```
[root@node1 ~]# curl -X POST -I http://localhost:32221/metrics
HTTP/1.1 405 Method Not Allowed
content-length: 0
date: Mon, 26 Feb 2024 11:27:12 GMT

[root@node1 ~]# curl -X GET -I http://localhost:32221/metrics
HTTP/1.1 200 OK
content-type: text/plain; version=0.0.4
content-length: 4766
date: Mon, 26 Feb 2024 11:27:18 GMT
```