### PR TITLE
Add lustre changelog user stats output

### DIFF
--- a/fixtures/stats.json
+++ b/fixtures/stats.json
@@ -2381,6 +2381,42 @@
   },
   {
     "Target": {
+      "Changelog": {
+        "kind": "Mdt",
+        "param": "changelog_users",
+        "target": "ai400x2-MDT0000",
+        "value": {
+          "users": 
+            [
+              {
+                "user": "cl2",
+                "index": 8,
+                "idle_secs": 180
+              }
+            ],
+          "current_index": 50
+          }
+        }
+    }
+  },
+  {
+    "Target": {
+      "Changelog": {
+        "kind": "Mdt",
+        "param": "changelog_users",
+        "target": "ai400x2-MDT0001",
+        "value": {
+          "users": 
+            [
+
+            ],
+          "current_index": 0
+          }
+        }
+    }
+  },
+  {
+    "Target": {
       "Stats": {
         "kind": "Mdt",
         "param": "md_stats",

--- a/src/snapshots/lustrefs_exporter__tests__stats.snap
+++ b/src/snapshots/lustrefs_exporter__tests__stats.snap
@@ -16,6 +16,19 @@ lustre_capacity_kilobytes{component="mdt",target="ai400x2-MDT0000"} 427170984
 lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0000"} 34750424936
 lustre_capacity_kilobytes{component="ost",target="ai400x2-OST0001"} 34750424936
 
+# HELP lustre_changelog_current_index current changelog index.
+# TYPE lustre_changelog_current_index gauge
+lustre_changelog_current_index{target="ai400x2-MDT0000"} 50
+lustre_changelog_current_index{target="ai400x2-MDT0001"} 0
+
+# HELP lustre_changelog_user_idle_sec current changelog user idle seconds.
+# TYPE lustre_changelog_user_idle_sec gauge
+lustre_changelog_user_idle_sec{user="cl2"} 180
+
+# HELP lustre_changelog_user_index current, maximum changelog index per registered changelog user.
+# TYPE lustre_changelog_user_index gauge
+lustre_changelog_user_index{user="cl2",target="ai400x2-MDT0000"} 8
+
 # HELP lustre_connected_clients Number of connected clients
 # TYPE lustre_connected_clients gauge
 lustre_connected_clients{component="mdt",target="ai400x2-MDT0000"} 1


### PR DESCRIPTION
This PR includes functionality to query and report on the status of changelog users for each MDT. 
This will provide a more granular insight into the changelog processing performance.

The output format is as follows:

```
mds# lctl get_param mdd.lustre-MDT0000.changelog_users
mdd.lustre-MDT0000.changelog_users=current index: 8
ID    index (idle seconds)
cl2   8 (180)
```

This depends on https://github.com/whamcloud/lustre-collector/pull/66