### PR TITLE
Add exporter configurable port

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bumpalo"
 version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +174,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -256,6 +263,16 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "fnv"
@@ -475,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
 name = "lock_api"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +533,7 @@ dependencies = [
 name = "lustrefs-exporter"
 version = "0.2.11"
 dependencies = [
+ "clap",
  "insta",
  "lustre_collector",
  "num-traits",
@@ -776,7 +800,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -860,6 +884,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags 2.5.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,7 +966,7 @@ version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1066,6 +1103,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
+dependencies = [
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ name = "lustrefs-exporter"
 version = "0.2.11"
 
 [dependencies]
+clap = {version = "4", features = ["derive", "env", "wrap_help", "string"]}
 lustre_collector = "0.7"
 num-traits = "0.2.14"
 prometheus = "0.13.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,21 +2,32 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
+use clap::Parser;
 use lustre_collector::{parse_lctl_output, parse_lnetctl_output, parse_lnetctl_stats, parser};
 use lustrefs_exporter::build_lustre_stats;
 use prometheus_exporter_base::prelude::*;
 
 use tokio::process::Command;
 
+const LUSTREFS_EXPORTER_PORT: &str = "32221";
+
 #[derive(Debug)]
 struct Options;
+
+#[derive(Debug, Parser)]
+pub struct CommandOpts {
+    /// Port that exporter will listen to
+    #[clap(short, long, env = "LUSTREFS_EXPORTER_PORT", default_value = LUSTREFS_EXPORTER_PORT)]
+    pub port: u16,
+}
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
+    let opts = CommandOpts::parse();
 
     let server_opts = ServerOptions {
-        addr: ([0, 0, 0, 0], 32221).into(),
+        addr: ([0, 0, 0, 0], opts.port).into(),
         authorization: Authorization::None,
     };
 


### PR DESCRIPTION
Provide the ability to set port that the exporter will listen to, through:
- `--port` option
- `LUSTREFS_EXPORTER_PORT` env variable

```
[root@node1 ~]# lustrefs-exporter --help
Usage: lustrefs-exporter [OPTIONS]

Options:
  -p, --port <PORT>  Port that exporter will listen to [env: LUSTREFS_EXPORTER_PORT=] [default: 32221]
  -h, --help         Print help
[root@node1 ~]# cat /lib/systemd/system/lustrefs_exporter.service.d/90-port.conf
[Service]
Environment="LUSTREFS_EXPORTER_PORT=32229"
[root@node1 ~]# systemctl daemon-reload
[root@node1 ~]# systemctl start lustrefs_exporter
[root@node1 ~]# systemctl status lustrefs_exporter
● lustrefs_exporter.service - Prometheus exporter for Lustre filesystem
   Loaded: loaded (/usr/lib/systemd/system/lustrefs_exporter.service; enabled; vendor preset: disabled)
  Drop-In: /usr/lib/systemd/system/lustrefs_exporter.service.d
           └─90-port.conf
   Active: active (running) since Tue 2024-04-23 09:07:28 UTC; 1s ago
     Docs: https://github.com/whamcloud/lustrefs-exporter
 Main PID: 3366895 (lustrefs_export)
    Tasks: 25 (limit: 1321392)
   Memory: 3.1M
   CGroup: /system.slice/lustrefs_exporter.service
           └─3366895 /usr/bin/lustrefs_exporter

Apr 23 09:07:28 node1 systemd[1]: Started Prometheus exporter for Lustre filesystem.
Apr 23 09:07:28 node1 lustrefs_exporter[3366895]: 2024-04-23T09:07:28.101174Z  INFO prometheus_exporter_base: Listening on http://0.0.0.0:32229/metrics
```