### PR TITLE
Add get param to disable jobstats and control max memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "504bdec147f2cc13c8b57ed9401fd8a147cc66b67ad5cb241394244f2c947549"
 
 [[package]]
 name = "cfg-if"
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f203fa8daa7bb185f760ae12bd8e097f63d17041dcdcaf675ac54cdf863170e"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -1044,18 +1044,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "e33aedb1a7135da52b7c21791455563facbbcc43d0f0f66165b42c21b3dfb150"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.205"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "692d6f5ac90220161d6774db30c662202721e64aed9058d2c394f451261420c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -676,6 +676,7 @@ dependencies = [
  "prometheus",
  "prometheus_exporter_base",
  "regex",
+ "serde",
  "serde_json",
  "thiserror",
  "tokio",

--- a/lustre-collector/src/quota/quota_parser.rs
+++ b/lustre-collector/src/quota/quota_parser.rs
@@ -97,7 +97,7 @@ where
 }
 
 #[derive(Debug)]
-pub enum QMTStat {
+pub(crate) enum QMTStat {
     Usr(Vec<QuotaStat>),
     Prj(Vec<QuotaStat>),
     Grp(Vec<QuotaStat>),

--- a/lustrefs-exporter/Cargo.toml
+++ b/lustrefs-exporter/Cargo.toml
@@ -13,7 +13,7 @@ num-traits = "0.2"
 prometheus = "0.13"
 prometheus_exporter_base = {version = "1.4.0"}
 regex = {version = "1", default-features = false, features = ["perf", "std", "perf-dfa-full"]}
-serde = { version = "1.0", features = ["derive"] }
+serde = {version = "1", features = ["derive"]}
 thiserror = "1"
 tokio = {workspace = true, features = [
   "rt-multi-thread",
@@ -26,8 +26,8 @@ tracing-subscriber = {workspace = true, features = ["env-filter"]}
 tracing.workspace = true
 
 [dev-dependencies]
-const_format = "0.2.32"
 combine.workspace = true
+const_format = "0.2.32"
 include_dir.workspace = true
 insta.workspace = true
 serde_json = "1"

--- a/lustrefs-exporter/Cargo.toml
+++ b/lustrefs-exporter/Cargo.toml
@@ -13,6 +13,7 @@ num-traits = "0.2"
 prometheus = "0.13"
 prometheus_exporter_base = {version = "1.4.0"}
 regex = {version = "1", default-features = false, features = ["perf", "std", "perf-dfa-full"]}
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1"
 tokio = {workspace = true, features = [
   "rt-multi-thread",

--- a/lustrefs-exporter/fixtures/jobstats_only/some_empty.txt
+++ b/lustrefs-exporter/fixtures/jobstats_only/some_empty.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3aaa9e9f0daf3ca55b889bec0b1b57efdeaf2864da58b8ac6196956a48fb43e
+size 2260

--- a/lustrefs-exporter/lustrefs_exporter.service
+++ b/lustrefs-exporter/lustrefs_exporter.service
@@ -6,6 +6,8 @@ Documentation=https://github.com/whamcloud/lustrefs-exporter
 Environment=RUST_LOG=info
 Restart=on-failure
 ExecStart=/usr/bin/lustrefs_exporter
+MemoryHigh=1750M
+MemoryMax=2G
 
 [Install]
 WantedBy=multi-user.target

--- a/lustrefs-exporter/src/main.rs
+++ b/lustrefs-exporter/src/main.rs
@@ -5,6 +5,7 @@
 use axum::{
     body::{Body, Bytes},
     error_handling::HandleErrorLayer,
+    extract::Query,
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::get,
@@ -13,6 +14,7 @@ use axum::{
 use clap::Parser;
 use lustre_collector::{parse_lctl_output, parse_lnetctl_output, parse_lnetctl_stats, parser};
 use lustrefs_exporter::{build_lustre_stats, Error};
+use serde::{Deserialize, Deserializer};
 use std::{
     borrow::Cow,
     convert::Infallible,
@@ -50,6 +52,29 @@ async fn handle_error(error: BoxError) -> impl IntoResponse {
     )
 }
 
+fn default_as_true() -> bool {
+    true
+}
+
+#[derive(Debug, Deserialize)]
+struct Params {
+    // Only disable jobstats if "jobstats=false"
+    #[serde(default = "default_as_true", deserialize_with = "empty_string_as_true")]
+    jobstats: bool,
+}
+
+/// Serde deserialization decorator to map empty Strings to None,
+fn empty_string_as_true<'de, D>(de: D) -> Result<bool, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<String>::deserialize(de)?;
+    match opt.as_deref() {
+        Some("false") => Ok(false),
+        _ => Ok(true),
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
@@ -76,7 +101,7 @@ async fn main() -> Result<(), Error> {
     Ok(())
 }
 
-async fn scrape() -> Result<Response<Body>, Error> {
+async fn scrape(Query(params): Query<Params>) -> Result<Response<Body>, Error> {
     let mut output = vec![];
 
     let lctl = Command::new("lctl")
@@ -112,36 +137,41 @@ async fn scrape() -> Result<Response<Body>, Error> {
 
     output.append(&mut lnetctl_stats_record);
 
-    let reader = tokio::task::spawn_blocking(move || {
-        let mut lctl_jobstats = std::process::Command::new("lctl")
-            .arg("get_param")
-            .args(["obdfilter.*OST*.job_stats", "mdt.*.job_stats"])
-            .stdout(std::process::Stdio::piped())
-            .spawn()?;
+    let s = if params.jobstats {
+        let reader = tokio::task::spawn_blocking(move || {
+            let mut lctl_jobstats = std::process::Command::new("lctl")
+                .arg("get_param")
+                .args(["obdfilter.*OST*.job_stats", "mdt.*.job_stats"])
+                .stdout(std::process::Stdio::piped())
+                .spawn()?;
 
-        let reader = BufReader::with_capacity(
-            128 * 1_024,
-            lctl_jobstats.stdout.take().ok_or(io::Error::new(
-                io::ErrorKind::NotFound,
-                "stdout missing for lctl jobstats call.",
-            ))?,
-        );
+            let reader = BufReader::with_capacity(
+                128 * 1_024,
+                lctl_jobstats.stdout.take().ok_or(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    "stdout missing for lctl jobstats call.",
+                ))?,
+            );
 
-        Ok::<_, Error>(reader)
-    })
-    .await??;
+            Ok::<_, Error>(reader)
+        })
+        .await??;
 
-    let (_, rx) = lustrefs_exporter::jobstats::jobstats_stream(reader);
+        let (_, rx) = lustrefs_exporter::jobstats::jobstats_stream(reader);
 
-    let stream = ReceiverStream::new(rx)
-        .map(|x| Bytes::from_iter(x.into_bytes()))
-        .map(Ok);
+        let stream = ReceiverStream::new(rx)
+            .map(|x| Bytes::from_iter(x.into_bytes()))
+            .map(Ok);
 
-    let lustre_stats = Ok::<_, Infallible>(build_lustre_stats(output).into());
+        let lustre_stats = Ok::<_, Infallible>(build_lustre_stats(output).into());
 
-    let merged = tokio_stream::StreamExt::merge(tokio_stream::once(lustre_stats), stream);
+        let merged = tokio_stream::StreamExt::merge(tokio_stream::once(lustre_stats), stream);
 
-    let s = Body::from_stream(merged);
+        Body::from_stream(merged)
+    } else {
+        tracing::debug!("Jobstats is disabled");
+        Body::from(build_lustre_stats(output))
+    };
 
     let response_builder = Response::builder().status(StatusCode::OK);
 


### PR DESCRIPTION
Add a GET param `jobstats` to disable jobstats collection and processing. Will only disable jobstats if the parameter is == `jobstats=false`

Add `MemoryHigh`/`MemoryMax` in systemd service file to control max memory

```
[root@es18ke-co-vm03 ~]# curl -G http://localhost:32221/metrics -d "jobstats" | grep jobid | wc -l
54
[root@es18ke-co-vm03 ~]# curl -G http://localhost:32221/metrics -d "jobstats=any" | grep jobid | wc -l
54
[root@es18ke-co-vm03 ~]# curl -G http://localhost:32221/metrics -d "jobstats=false" | grep jobid | wc -l
0
[root@es18ke-co-vm03 ~]# curl -G http://localhost:32221/metrics | grep jobid | wc -l
54
```