### PR TITLE
Handle new jobstats format

### DIFF
--- a/lustrefs-exporter/fixtures/jobstats_only/2.14.0_162.txt
+++ b/lustrefs-exporter/fixtures/jobstats_only/2.14.0_162.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:099ac60512738d1c71ffc1fbf52c5a3bf6f688c65ef5014578c24dd9a53b924d
+size 37136

--- a/lustrefs-exporter/src/jobstats.rs
+++ b/lustrefs-exporter/src/jobstats.rs
@@ -82,8 +82,15 @@ pub fn jobstats_stream<R: BufRead + std::marker::Send + 'static>(
     ) -> Result<(State, LoopInstruction), Error> {
         let line = maybe_line?;
 
+        // println!("{:?}: {line}", state);
+
         match state {
-            _ if line == "job_stats:" || line.starts_with("  snapshot_time:") => {
+            _ if line == "job_stats:"
+                || line.starts_with("  snapshot_time:")
+                || line.starts_with("  start_time:")
+                || line.starts_with("  elapsed_time:")
+                || line.starts_with("  snapshot_time:") =>
+            {
                 return Ok((state, LoopInstruction::Noop))
             }
             State::Empty if line.starts_with("obdfilter") || line.starts_with("mdt.") => {
@@ -118,7 +125,6 @@ pub fn jobstats_stream<R: BufRead + std::marker::Send + 'static>(
             }
             x => {
                 tracing::debug!("Unexpected line: {line}, state: {x:?}");
-
                 return Ok((x, LoopInstruction::Return));
             }
         }
@@ -350,6 +356,25 @@ pub mod tests {
         fut.await.unwrap();
 
         assert_eq!(cnt, 5_310_036);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn parse_new_yaml() {
+        let f = File::open("fixtures/jobstats_only/2.14.0_162.txt").unwrap();
+
+        let f = BufReader::with_capacity(128 * 1_024, f);
+
+        let (fut, mut rx) = jobstats_stream(f);
+
+        let mut cnt = 0;
+
+        while rx.recv().await.is_some() {
+            cnt += 1;
+        }
+
+        fut.await.unwrap();
+
+        assert_eq!(cnt, 1_728);
     }
 
     const JOBSTAT_JOB: &str = r#"

--- a/lustrefs-exporter/src/jobstats.rs
+++ b/lustrefs-exporter/src/jobstats.rs
@@ -82,8 +82,6 @@ pub fn jobstats_stream<R: BufRead + std::marker::Send + 'static>(
     ) -> Result<(State, LoopInstruction), Error> {
         let line = maybe_line?;
 
-        // println!("{:?}: {line}", state);
-
         match state {
             _ if line == "job_stats:"
                 || line.starts_with("  start_time:")

--- a/lustrefs-exporter/src/jobstats.rs
+++ b/lustrefs-exporter/src/jobstats.rs
@@ -86,7 +86,6 @@ pub fn jobstats_stream<R: BufRead + std::marker::Send + 'static>(
 
         match state {
             _ if line == "job_stats:"
-                || line.starts_with("  snapshot_time:")
                 || line.starts_with("  start_time:")
                 || line.starts_with("  elapsed_time:")
                 || line.starts_with("  snapshot_time:") =>


### PR DESCRIPTION
Fix a bug with latest jobstats output:
```
2024-08-08T11:14:17.126312Z DEBUG lustrefs_exporter::jobstats: Unexpected error processing jobstats lines: Could not find match for job_stat in   start_time:      1723102025.057286226 secs.nsecs
```