### PR TITLE
Implement a 120s timeout in case lctl process is taking too long

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,6 +866,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1669,6 +1670,15 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/lustrefs-exporter/Cargo.toml
+++ b/lustrefs-exporter/Cargo.toml
@@ -19,11 +19,13 @@ tokio = {workspace = true, features = [
   "rt-multi-thread",
   "macros",
   "process",
+  "time",
 ]}
 tokio-stream = "0.1.15"
 tower = {version = "0.4.13", features = ["timeout", "load-shed", "limit"]}
 tracing-subscriber = {workspace = true, features = ["env-filter"]}
 tracing.workspace = true
+wait-timeout = "0.2.0"
 
 [dev-dependencies]
 combine.workspace = true

--- a/lustrefs-exporter/src/lib.rs
+++ b/lustrefs-exporter/src/lib.rs
@@ -40,6 +40,8 @@ pub enum Error {
     Utf8(#[from] std::str::Utf8Error),
     #[error("Could not find match for {0} in {1}")]
     NoCap(&'static str, String),
+    #[error(transparent)]
+    Timeout(#[from] tokio::time::error::Elapsed),
 }
 
 impl IntoResponse for Error {


### PR DESCRIPTION
Demo below is using a timeout of 5s (instead of 120s from this PR):

```
[root@node ~]# RUST_LOG=debug ./lustrefs-exporter --port 34221
2024-09-06T15:49:34.617893Z  INFO lustrefs_exporter: Listening on http://0.0.0.0:34221/metrics
2024-09-06T15:49:41.238172Z DEBUG lustrefs_exporter: lctl jobstats timed out

[root@es18kxe-co-vm07 ~]# time curl http://localhost:34221/metrics | tail
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 75.1M    0 75.1M    0     0  15.0M      0 --:--:--  0:00:05 --:--:-- 16.7M
lustre_job_stats_total{operation="getattr",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="setattr",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="punch",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="sync",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="destroy",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="create",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="statfs",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="get_info",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="set_info",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0
lustre_job_stats_total{operation="quotactl",component="ost",target="testfs-OST0003",jobid="SLURM_JOB199002:0:client"} 0

real    0m5.014s
user    0m0.883s
sys     0m1.449s
```