### PR TITLE
Reverse jobstats HTTP param behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           find lustrefs-exporter/_rpm -type f -name \*.rpm -print -exec rpm -qivlp {} \;
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rocky8_rpm
           retention-days: 1
@@ -89,7 +89,7 @@ jobs:
           find lustrefs-exporter/_rpm -type f -name \*.rpm -print -exec rpm -qivlp {} \;
 
       - name: Upload RPMs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: rocky9_rpm
           retention-days: 1
@@ -132,7 +132,7 @@ jobs:
           find lustrefs-exporter/_deb -type f -name \*.deb -print -exec dpkg -I {} \; -exec dpkg -c {} \;
 
       - name: Upload DEBs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: ubuntu20_debs
           retention-days: 1

--- a/lustrefs-exporter/src/main.rs
+++ b/lustrefs-exporter/src/main.rs
@@ -52,14 +52,14 @@ async fn handle_error(error: BoxError) -> impl IntoResponse {
     )
 }
 
-fn default_as_true() -> bool {
-    true
+fn default_as_false() -> bool {
+    false
 }
 
 #[derive(Debug, Deserialize)]
 struct Params {
-    // Only disable jobstats if "jobstats=false"
-    #[serde(default = "default_as_true")]
+    // Only enable jobstats if "jobstats=true"
+    #[serde(default = "default_as_false")]
     jobstats: bool,
 }
 

--- a/lustrefs-exporter/src/main.rs
+++ b/lustrefs-exporter/src/main.rs
@@ -52,14 +52,10 @@ async fn handle_error(error: BoxError) -> impl IntoResponse {
     )
 }
 
-fn default_as_false() -> bool {
-    false
-}
-
 #[derive(Debug, Deserialize)]
 struct Params {
     // Only enable jobstats if "jobstats=true"
-    #[serde(default = "default_as_false")]
+    #[serde(default)]
     jobstats: bool,
 }
 


### PR DESCRIPTION
Reverse the behavior of the "jobstats" HTTP param.

```
[root@node1 ~]# curl -s -G http://localhost:32221/metrics | grep jobid | wc -l
0
[root@node1 ~]# curl -s -G http://localhost:32221/metrics -d "jobstats" | grep jobid | wc -l
0
[root@node1 ~]# curl -s -G http://localhost:32221/metrics -d "jobstats=any" | grep jobid | wc -l
0
[root@node1 ~]# curl -s -G http://localhost:32221/metrics -d "jobstats=true" | grep jobid | wc -l
66
```
`0` means no jobstats are shown/processed