### PR TITLE
Dump stats for debugging purpose using '--dump' option

### DIFF
--- a/lustrefs-exporter/src/main.rs
+++ b/lustrefs-exporter/src/main.rs
@@ -87,6 +87,15 @@ async fn main() -> Result<(), Error> {
             .await?;
         println!("{}", std::str::from_utf8(&lctl.stdout)?);
 
+        println!("# Dumping lctl get_param jobstats output");
+        let lctl = Command::new("lctl")
+            .arg("get_param")
+            .args(["obdfilter.*OST*.job_stats", "mdt.*.job_stats"])
+            .kill_on_drop(true)
+            .output()
+            .await?;
+        println!("{}", std::str::from_utf8(&lctl.stdout)?);
+
         println!("# Dumping lnetctl net show output");
         let lnetctl = Command::new("lnetctl")
             .args(["net", "show", "-v", "4"])


### PR DESCRIPTION
Add a new `--dump` option to dump stats that are then parsed.
This is useful for debugging purpose.

# Demo
```
[root@server ~]# lustrefs-exporter --dump
# Dumping lctl get_param output
memused=7366308585
memused_max=7453967617
lnet_memused=121517348
health_check=healthy
ldlm.services.ldlm_cbd.stats=
snapshot_time             1742210395.526617175 secs.nsecs
start_time                1742198638.967129679 secs.nsecs
elapsed_time              11756.559487496 secs.nsecs
req_waittime              238615 samples [usecs] 2 70426 308412852 2832281043026
req_qdepth                238615 samples [reqs] 0 26 3542 5592
req_active                238615 samples [reqs] 1 4 257523 297939
req_timeout               238615 samples [secs] 15 15 3579225 53688375
reqbuf_avail              476895 samples [bufs] 0 2 440734 441926
ldlm_bl_callback          158245 samples [usecs] 2 23139 1718684 2615598552
ldlm_cp_callback          80370 samples [usecs] 6 19916 2274836 13454316108
llite.ncpqlc-ff3694d8f2f17000.stats=
snapshot_time             1742210395.526739859 secs.nsecs
start_time                1742198638.969749273 secs.nsecs
elapsed_time              11756.556990586 secs.nsecs
read_bytes                15024767 samples [bytes] 40 1048576 15749376641112 16513681650568294040
write_bytes               15357479 samples [bytes] 79 4194304 16142136508574 17088386518034165954
read                      15019806 samples [usecs] 1 5341491 159691593057 36742197448890125
write                     15357479 samples [usecs] 51 924541 293256875475 10710841704369377
ioctl                     26 samples [reqs]
open                      1956 samples [usecs] 0 24343 6231951 109763338801
close                     1908 samples [usecs] 2 23138 1645363 12296124013
seek                      30365037 samples [usecs] 0 74247 7576569 8218687737
fsync                     912 samples [usecs] 213 2853433 210083892 193061055340526
readdir                   12 samples [usecs] 0 554 2579 1165469
setattr                   1 samples [usecs] 144 144 144 20736
truncate                  49 samples [usecs] 697 155553 1866677 140037134485
getattr                   2260 samples [usecs] 2 93380 12318051 561642054799
unlink                    488 samples [usecs] 246 43994 456235 3114823937
mkdir                     5 samples [usecs] 758 5890 12765 47910061
mknod                     538 samples [usecs] 137 69604 573735 15242767987
statfs                    7 samples [usecs] 103 3958 4832 15804810
getxattr                  50 samples [usecs] 2 1994 35870 33848296
getxattr_hits             1 samples [reqs]
inode_permission          20488 samples [usecs] 0 1164 326017 74166605
opencount                 1956 samples [reqs] 1 39 5736 97540
openclosetime             327 samples [usecs] 122 2936950804 15006146286 844419776511885236

# Dumping lctl get_param jobstats output

# Dumping lnetctl net show output
net:
    - net type: lo
      local NI(s):
        - nid: 0@lo
          status: up
          statistics:
              send_count: 0
              recv_count: 0
              drop_count: 0
          sent_stats:
              put: 0
              get: 0
              reply: 0
              ack: 0
              hello: 0
          received_stats:
              put: 0
              get: 0
              reply: 0
              ack: 0
              hello: 0
          dropped_stats:
              put: 0
              get: 0
              reply: 0
              ack: 0
              hello: 0
          health stats:
              fatal_error: 0
              health value: 0
              interrupts: 0
              dropped: 0
              aborted: 0
              no route: 0
              timeouts: 0
              error: 0
              ping_count: 0
              next_ping: 0
          tunables:
              peer_timeout: 0
              peer_credits: 0
              peer_buffer_credits: 0
              credits: 0
          lnd tunables:
          dev cpt: 0
          CPT: "[0,1,2,3,4,5,6,7,8,9,10,11]"
    - net type: o2ib
      local NI(s):
        - nid: 192.168.0.216@o2ib
          status: up
          interfaces:
              0: bond0
          statistics:
              send_count: 47965105
              recv_count: 63812507
              drop_count: 0
          sent_stats:
              put: 47965101
              get: 4
              reply: 0
              ack: 0
              hello: 0
          received_stats:
              put: 47964012
              get: 0
              reply: 15848491
              ack: 4
              hello: 0
          dropped_stats:
              put: 0
              get: 0
              reply: 0
              ack: 0
              hello: 0
          health stats:
              fatal_error: 0
              health value: 1000
              interrupts: 0
              dropped: 0
              aborted: 0
              no route: 0
              timeouts: 0
              error: 0
              ping_count: 0
              next_ping: 0
          tunables:
              peer_timeout: 180
              peer_credits: 32
              peer_buffer_credits: 0
              credits: 256
          lnd tunables:
              peercredits_hiw: 16
              map_on_demand: 1
              concurrent_sends: 64
              fmr_pool_size: 512
              fmr_flush_trigger: 384
              fmr_cache: 1
              ntx: 512
              conns_per_peer: 1
          dev cpt: -1
          CPT: "[0,1,2,3,4,5,6,7,8,9,10,11]"

# Dumping lnetctl stats show output
statistics:
    msgs_alloc: 12
    msgs_max: 2330
    rst_alloc: 0
    errors: 0
    send_count: 47965109
    resend_count: 0
    response_timeout_count: 0
    local_interrupt_count: 0
    local_dropped_count: 0
    local_aborted_count: 0
    local_no_route_count: 0
    local_timeout_count: 0
    local_error_count: 0
    remote_dropped_count: 0
    remote_error_count: 0
    remote_timeout_count: 0
    network_timeout_count: 0
    recv_count: 63812508
    route_count: 0
    drop_count: 0
    send_length: 16633634884832
    recv_length: 16539566583064
    route_length: 0
    drop_length: 0
```