### PR TITLE
Update help message for 'lustre_health_healthy'

### DIFF
--- a/lustrefs-exporter/src/host.rs
+++ b/lustrefs-exporter/src/host.rs
@@ -23,7 +23,7 @@ pub mod opentelemetry {
             OpenTelemetryMetricsHost {
                 lustre_targets_healthy: meter
                     .u64_gauge("lustre_health_healthy")
-                    .with_description("Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.")
+                    .with_description("Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.")
                     .build(),
                 lnet_mem_used: meter
                     .u64_gauge("lustre_lnet_mem_used")

--- a/lustrefs-exporter/src/main.rs
+++ b/lustrefs-exporter/src/main.rs
@@ -525,10 +525,11 @@ mod tests {
     }
 
     fn normalize_docs(docs: &std::collections::HashMap<String, String>) -> Vec<(String, String)> {
+        // Ignore updated metrics since OTEL move.
         let mut sorted_docs: Vec<_> = docs
             .iter()
             .filter_map(|(k, v)| {
-                if k != "target_info" {
+                if k != "target_info" && k != "lustre_health_healthy" {
                     Some((k.clone(), v.clone()))
                 } else {
                     None
@@ -540,7 +541,7 @@ mod tests {
     }
 
     fn compare_metrics(metrics1: &Scrape, metrics2: &Scrape) {
-        // Skip OTEL specific metric
+        // Skip OTEL specific metric and updated metrics.
         let set1: HashSet<_> = metrics1
             .samples
             .iter()

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__client_stats_otel.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__client_stats_otel.snap
@@ -56,7 +56,7 @@ lustre_drop_bytes_total{otel_scope_name="lustre"} 0
 # TYPE lustre_drop_count_total counter
 lustre_drop_count_total{nid="0@lo",otel_scope_name="lustre"} 0
 lustre_drop_count_total{nid="172.18.2.101@o2ib",otel_scope_name="lustre"} 0
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_ldlm_cbd_stats Gives information about LDLM Callback service.

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__host_stats_non_healthy_otel.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__host_stats_non_healthy_otel.snap
@@ -349,7 +349,7 @@ lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 1978628
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 34539581312
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 34540373392
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 0
 lustre_health_healthy{target="lustre-OST0012",otel_scope_name="lustre"} 0

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__lnetctl_stats_mds_otel.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__lnetctl_stats_mds_otel.snap
@@ -199,7 +199,7 @@ lustre_free_kilobytes{component="mdt",target="fs-MDT0000",otel_scope_name="lustr
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 489888
 lustre_free_kilobytes{component="ost",target="fs-OST0000",otel_scope_name="lustre"} 4004584
 lustre_free_kilobytes{component="ost",target="fs-OST0001",otel_scope_name="lustre"} 4106984
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__lnetctl_stats_otel.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__lnetctl_stats_otel.snap
@@ -228,7 +228,7 @@ lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 2026160128
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 2395312779264
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 1295779098624
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__stats_otel.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__stats_otel.snap
@@ -370,7 +370,7 @@ lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 1978628
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 34539581312
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 34540373392
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_ex8761-lctl.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_ex8761-lctl.txt.snap
@@ -41,7 +41,7 @@ lustre_free_kilobytes{component="mdt",target="fs-MDT0000",otel_scope_name="lustr
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 489272
 lustre_free_kilobytes{component="ost",target="fs-OST0000",otel_scope_name="lustre"} 4105984
 lustre_free_kilobytes{component="ost",target="fs-OST0001",otel_scope_name="lustre"} 4105984
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 0
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2-14-0__client__llite_client.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2-14-0__client__llite_client.txt.snap
@@ -18,7 +18,7 @@ lustre_client_stats{operation="rmdir",target="ai400x2-ff47bce9ca35d800",otel_sco
 lustre_client_stats{operation="setxattr",target="ai400x2-ff47bce9ca35d800",otel_scope_name="lustre"} 1
 lustre_client_stats{operation="statfs",target="ai400x2-ff47bce9ca35d800",otel_scope_name="lustre"} 17864
 lustre_client_stats{operation="unlink",target="ai400x2-ff47bce9ca35d800",otel_scope_name="lustre"} 17977752
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_ldlm_cbd_stats Gives information about LDLM Callback service.

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn133__2.14.0_ddn133_exports.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn133__2.14.0_ddn133_exports.txt.snap
@@ -1033,7 +1033,7 @@ lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 1978660
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 31831867004
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 31760657736
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn133__2.14.0_ddn133_quota.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn133__2.14.0_ddn133_quota.txt.snap
@@ -623,7 +623,7 @@ lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 1978660
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 31831867004
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 31760657736
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn145__2.14.0_ddn145_stats.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_lustre-2.14.0_ddn145__2.14.0_ddn145_stats.txt.snap
@@ -64,7 +64,7 @@ lustre_free_kilobytes{component="mdt",target="fs-MDT0000",otel_scope_name="lustr
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 489920
 lustre_free_kilobytes{component="ost",target="fs-OST0000",otel_scope_name="lustre"} 4106852
 lustre_free_kilobytes{component="ost",target="fs-OST0001",otel_scope_name="lustre"} 4106852
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_params-6.2.0-r9.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_params-6.2.0-r9.txt.snap
@@ -41,7 +41,7 @@ lustre_free_kilobytes{component="mdt",target="fs-MDT0000",otel_scope_name="lustr
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 489272
 lustre_free_kilobytes{component="ost",target="fs-OST0000",otel_scope_name="lustre"} 4106144
 lustre_free_kilobytes{component="ost",target="fs-OST0001",otel_scope_name="lustre"} 4106144
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 0
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid.txt.snap
@@ -117,7 +117,7 @@ lustre_exports_total{component="ost",target="ai400-OST0001",otel_scope_name="lus
 lustre_free_kilobytes{component="mdt",target="ai400-MDT0000",otel_scope_name="lustre"} 110616588
 lustre_free_kilobytes{component="ost",target="ai400-OST0000",otel_scope_name="lustre"} 3875693364
 lustre_free_kilobytes{component="ost",target="ai400-OST0001",otel_scope_name="lustre"} 3978093456
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid2.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid2.txt.snap
@@ -41,7 +41,7 @@ lustre_free_kilobytes{component="mdt",target="testfs-MDT0000",otel_scope_name="l
 lustre_free_kilobytes{component="mgt",target="MGS",otel_scope_name="lustre"} 1978672
 lustre_free_kilobytes{component="ost",target="testfs-OST0000",otel_scope_name="lustre"} 34750423116
 lustre_free_kilobytes{component="ost",target="testfs-OST0001",otel_scope_name="lustre"} 34750423116
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_mds.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_mds.txt.snap
@@ -37,7 +37,7 @@ lustre_exports_total{component="ost",target="ai400x2-OST0001",otel_scope_name="l
 lustre_free_kilobytes{component="mdt",target="ai400x2-MDT0000",otel_scope_name="lustre"} 412951760
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0000",otel_scope_name="lustre"} 32878173676
 lustre_free_kilobytes{component="ost",target="ai400x2-OST0001",otel_scope_name="lustre"} 32884203100
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_no_newline.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_no_newline.txt.snap
@@ -107,7 +107,7 @@ lustre_exports_total{component="ost",target="ai400-OST0001",otel_scope_name="lus
 lustre_free_kilobytes{component="mdt",target="ai400-MDT0000",otel_scope_name="lustre"} 110616588
 lustre_free_kilobytes{component="ost",target="ai400-OST0000",otel_scope_name="lustre"} 3875693364
 lustre_free_kilobytes{component="ost",target="ai400-OST0001",otel_scope_name="lustre"} 3978093456
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 1
 # HELP lustre_inodes_free The number of inodes (objects) available

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_unhealthy_host.txt.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__tests__valid_fixture_otel_valid_unhealthy_host.txt.snap
@@ -107,7 +107,7 @@ lustre_exports_total{component="ost",target="ai400-OST0001",otel_scope_name="lus
 lustre_free_kilobytes{component="mdt",target="ai400-MDT0000",otel_scope_name="lustre"} 110616588
 lustre_free_kilobytes{component="ost",target="ai400-OST0000",otel_scope_name="lustre"} 3875693364
 lustre_free_kilobytes{component="ost",target="ai400-OST0001",otel_scope_name="lustre"} 3978093456
-# HELP lustre_health_healthy Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
+# HELP lustre_health_healthy Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
 # TYPE lustre_health_healthy gauge
 lustre_health_healthy{otel_scope_name="lustre"} 0
 lustre_health_healthy{target="lustre-OST0012",otel_scope_name="lustre"} 0


### PR DESCRIPTION
Update help message for `lustre_health_healthy` from:
```
Indicates whether the Lustre target is healthy or not. 1 is healthy, 0 is unhealthy.
```
to
```
Indicates whether the Lustre server is healthy or not. 1 is healthy, 0 is unhealthy.
```
as this metric is not tight to a specific target