### PR TITLE
Reduce log spam

### DIFF
--- a/lustrefs-exporter/lustrefs_exporter.service
+++ b/lustrefs-exporter/lustrefs_exporter.service
@@ -3,7 +3,7 @@ Description=Prometheus exporter for Lustre filesystem
 Documentation=https://github.com/whamcloud/lustrefs-exporter
 
 [Service]
-Environment=RUST_LOG=info
+Environment=RUST_LOG=info,opentelemetry_sdk=warn
 Restart=on-failure
 ExecStart=/usr/bin/lustrefs_exporter
 MemoryHigh=1750M

--- a/lustrefs-exporter/src/lib.rs
+++ b/lustrefs-exporter/src/lib.rs
@@ -83,9 +83,5 @@ pub fn init_opentelemetry() -> Result<
         )
         .build();
 
-    // Set the global MeterProvider to the one created above.
-    // This will make all meters created with `global::meter()` use the above MeterProvider.
-    opentelemetry::global::set_meter_provider(provider.clone());
-
     Ok((provider, registry))
 }


### PR DESCRIPTION
This PR increase the logging of the `opentelemetry_sdk` crate to `warn` to avoid printing message at every scrape.
It also remove the usage of global meter as it has no usage and also avoid printing message.

From:
```
May 13 20:27:10 node1 systemd[1]: Started Prometheus exporter for Lustre filesystem.
May 13 20:27:10 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:10.647047Z  INFO lustrefs_exporter: Listening on http://0.0.0.0:32221/metrics
May 13 20:27:35 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:35.807598Z  INFO opentelemetry:  name="MeterProvider.GlobalSet" Global meter provider is set. Meters can now be created using global::meter() or global::meter_with_scope().
May 13 20:27:45 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:45.796477Z  INFO opentelemetry_sdk:  name="MeterProvider.Drop" Last reference of MeterProvider dropped, initiating shutdown.
May 13 20:27:45 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:45.796785Z  INFO opentelemetry:  name="MeterProvider.GlobalSet" Global meter provider is set. Meters can now be created using global::meter() or global::meter_with_scope().
May 13 20:27:55 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:55.796079Z  INFO opentelemetry_sdk:  name="MeterProvider.Drop" Last reference of MeterProvider dropped, initiating shutdown.
May 13 20:27:55 node1 lustrefs_exporter[94199]: 2025-05-13T20:27:55.796375Z  INFO opentelemetry:  name="MeterProvider.GlobalSet" Global meter provider is set. Meters can now be created using global::meter() or global::meter_with_scope().
May 13 20:28:05 node1 lustrefs_exporter[94199]: 2025-05-13T20:28:05.805848Z  INFO opentelemetry_sdk:  name="MeterProvider.Drop" Last reference of MeterProvider dropped, initiating shutdown.
```

to

```
May 14 07:02:58 node1 systemd[1]: Started Prometheus exporter for Lustre filesystem.
May 14 07:02:58 node1 lustrefs_exporter[1229728]: 2025-05-14T07:02:58.466738Z  INFO lustrefs_exporter: Listening on http://0.0.0.0:32221/metrics
```