### PR TITLE
Update scrape benchmark to use http requests

### DIFF
--- a/.github/workflows/generate-memory-flamegraph.yml
+++ b/.github/workflows/generate-memory-flamegraph.yml
@@ -1,0 +1,123 @@
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+
+defaults:
+  run:
+    shell: bash -eux {0}
+
+jobs:
+  generate_memory_flamegraph:
+    name: Generate flamegraph
+    permissions:
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: rust-lang/rustc-demangle
+          path: rustc-demangle
+
+      - uses: actions/checkout@v4
+        with:
+          repository: KDE/heaptrack
+          path: heaptrack
+
+      - uses: actions/checkout@v4
+        with:
+          repository: brendangregg/FlameGraph
+          path: FlameGraph
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+
+          # Install heaptrack dependencies
+          sudo apt-get install -y \
+            build-essential libssl-dev pkg-config curl git \
+            cmake g++ libboost-dev libboost-iostreams-dev \
+            libboost-program-options-dev libdw-dev libelf-dev \
+            elfutils libunwind-dev zlib1g-dev binutils-dev \
+            libiberty-dev libdebuginfod-dev libboost-system-dev \
+            libboost-filesystem-dev libboost-thread-dev libboost-regex-dev
+
+            # Install rustfilt - used for demangling symbols
+            cargo install rustfilt
+
+      - name: Build and install librustc_demangle.so
+        run: |
+          cd rustc-demangle
+          cargo build -p rustc-demangle-capi --release
+          sudo mv target/release/librustc_demangle.so /usr/lib
+
+      - name: Build and install heaptrack
+        run: |
+          cd heaptrack
+          mkdir build && cd build
+
+          cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local -DHEAPTRACK_USE_LIBUNWIND=ON -DHEAPTRACK_BUILD_PRINT_TRACES=ON
+
+          make -j$(nproc)
+          sudo make install
+
+      - name: Build flamegraph
+        run: |
+           cargo build --profile profiling --test flamegraph_test
+        env:
+          RUSTFLAGS: "-C force-frame-pointers=yes -C symbol-mangling-version=v0"
+          CARGO_PROFILE_RELEASE_DEBUG: true
+
+      - name: Build heaptrack data
+        run: |
+          export TEST_BINARY=$(find "$GITHUB_WORKSPACE/target/profiling/deps" -name "flamegraph_test-*" -type f -executable | head -1)
+
+          if [ -z "$TEST_BINARY" ]; then
+            echo "Error: Could not find test binary"
+            exit 1
+          fi
+
+          "$TEST_BINARY" profile_with_flamegraph --ignored  --no-capture | head -100
+
+          heaptrack --output heaptrack-data "$TEST_BINARY" --ignored profile_with_flamegraph
+        env:
+          CARGO_MANIFEST_DIR: "$GITHUB_WORKSPACE/lustrefs-exporter"
+
+      - name: Generate flamegraph
+        run: |
+          heaptrack_print --version
+          HEAPTRACK_FILE=$(ls heaptrack-data.* | head -1)
+
+          echo "Writing flamegraph data to flamegraph-data.txt"
+          heaptrack_print "$HEAPTRACK_FILE" -F flamegraph-data.txt > /dev/null
+          echo "Done writing flamegraph data to flamegraph-data.txt: $?"
+
+          # Demangle symbols
+          rustfilt < flamegraph-data.txt > demangled-flamegraph.txt
+
+          # Filter out stacks with less than 1000 allocations. This has to be done because there are so many
+          # of them that flamegraph generation will fail.
+          awk '$NF > 1000' demangled-flamegraph.txt > significant_stacks.txt
+
+          # Generate the flamegraph
+          FlameGraph/flamegraph.pl --colors mem --countname allocations < significant_stacks.txt > flamegraph.svg
+
+      - name: Upload flamegraphs and heaptrack data
+        uses: actions/upload-artifact@v4
+        with:
+          name: flamegraph
+          path: |
+            flamegraph.svg
+            cpu-flamegraph.svg
+            heaptrack-data.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -117,6 +139,12 @@ name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-compression"
@@ -280,6 +308,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "bytes"
@@ -504,12 +538,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot 0.5.0",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
 ]
 
 [[package]]
@@ -522,7 +591,7 @@ dependencies = [
  "cast",
  "ciborium",
  "clap",
- "criterion-plot",
+ "criterion-plot 0.6.0",
  "itertools 0.13.0",
  "num-traits",
  "oorandom",
@@ -534,6 +603,16 @@ dependencies = [
  "tinytemplate",
  "tokio",
  "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -576,6 +655,15 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
 
 [[package]]
 name = "derive_more"
@@ -642,6 +730,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +781,18 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "flate2"
@@ -887,6 +1007,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -1229,6 +1355,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "inferno"
+version = "0.11.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "is-terminal",
+ "itoa",
+ "log",
+ "num-format",
+ "once_cell",
+ "quick-xml",
+ "rgb",
+ "str_stack",
+]
+
+[[package]]
 name = "insta"
 version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1259,10 +1403,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1373,10 +1537,11 @@ dependencies = [
  "combine",
  "commandeer-test",
  "const_format",
- "criterion",
+ "criterion 0.7.0",
  "iai-callgrind",
  "insta",
  "lustre_collector",
+ "pprof",
  "pretty_assertions",
  "prometheus-client",
  "prometheus-parse",
@@ -1414,6 +1579,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -1459,6 +1633,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1660,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-format"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
+dependencies = [
+ "arrayvec",
+ "itoa",
 ]
 
 [[package]]
@@ -1648,6 +1843,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pprof"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a01da47675efa7673b032bf8efd8214f1917d89685e07e395ab125ea42b187"
+dependencies = [
+ "aligned-vec",
+ "backtrace",
+ "cfg-if",
+ "criterion 0.5.1",
+ "findshlibs",
+ "inferno",
+ "libc",
+ "log",
+ "nix",
+ "once_cell",
+ "smallvec",
+ "spin",
+ "symbolic-demangle",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1719,6 +1937,15 @@ dependencies = [
  "itertools 0.12.1",
  "once_cell",
  "regex",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1847,6 +2074,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -2106,16 +2342,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "str_stack"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9091b6114800a5f2141aee1d1b9d6ca3592ac062dc5decb3764ec5895a47b4eb"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "symbolic-common"
+version = "12.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da12f8fecbbeaa1ee62c1d50dc656407e007c3ee7b2a41afce4b5089eaef15e"
+dependencies = [
+ "debugid",
+ "memmap2",
+ "stable_deref_trait",
+ "uuid",
+]
+
+[[package]]
+name = "symbolic-demangle"
+version = "12.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd35afe0ef9d35d3dcd41c67ddf882fc832a387221338153b7cd685a105495c"
+dependencies = [
+ "cpp_demangle",
+ "rustc-demangle",
+ "symbolic-common",
+]
 
 [[package]]
 name = "syn"
@@ -2471,6 +2745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2481,6 +2765,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -2962,6 +3252,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ criterion = "0.7"
 iai-callgrind = "0.16"
 include_dir = { version = "0.7", features = ["glob"] }
 insta = "1"
+pprof = "0.15"
 pretty_assertions = "1.4.1"
 prometheus-client = { git = "https://github.com/whamcloud/client_rust", branch = "whamcloud-08-12-2025" }
 prometheus-parse = "0.2.5"

--- a/lustrefs-exporter/Cargo.toml
+++ b/lustrefs-exporter/Cargo.toml
@@ -33,6 +33,7 @@ const_format.workspace = true
 criterion = { workspace = true, features = ["html_reports", "async_tokio"] }
 iai-callgrind.workspace = true
 insta = { workspace = true, features = ["glob"] }
+pprof = { workspace = true, features = ["criterion", "flamegraph"] }
 pretty_assertions.workspace = true
 prometheus-parse.workspace = true
 reqwest.workspace = true

--- a/lustrefs-exporter/benches/common/mod.rs
+++ b/lustrefs-exporter/benches/common/mod.rs
@@ -8,7 +8,7 @@ use tokio::{task::JoinSet, time::Instant};
 // Create a single request using `oneshot`. This is equivalent to hitting the
 // `/scrape` endpoint if the http service was running.
 async fn make_single_request() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    let body = reqwest::get("http://localhost:12345/metrics?jobstats=true")
+    let body = reqwest::get("http://0.0.0.0:12345/metrics?jobstats=true")
         .await?
         .text()
         .await?;

--- a/lustrefs-exporter/tests/flamegraph_test.rs
+++ b/lustrefs-exporter/tests/flamegraph_test.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2025 DDN. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+use commandeer_test::commandeer;
+use pprof::ProfilerGuardBuilder;
+use serial_test::serial;
+use std::time::{Duration, Instant};
+use tokio::task::JoinSet;
+
+#[commandeer(Replay, "lctl", "lnetctl")]
+#[tokio::test]
+#[serial]
+#[ignore]
+async fn profile_with_flamegraph() {
+    // Start CPU profiling
+    let cpu_guard = ProfilerGuardBuilder::default()
+        .frequency(100)
+        .build()
+        .unwrap();
+
+    // Start the server
+    let listener = tokio::net::TcpListener::bind(("0.0.0.0", 12345))
+        .await
+        .expect("Failed to bind to port 12345");
+
+    tokio::spawn(async move {
+        axum::serve(listener, lustrefs_exporter::routes::app())
+            .await
+            .expect("Failed to serve app.");
+    });
+
+    // Wait for server to be ready
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    // Run a load test
+    let _duration = load_test_concurrent(10, 50).await;
+
+    // Generate CPU flamegraph
+    if let Ok(report) = cpu_guard.report().build() {
+        let file = std::fs::File::create("cpu-flamegraph.svg").unwrap();
+        let mut options = pprof::flamegraph::Options::default();
+        report.flamegraph_with_options(&file, &mut options).unwrap();
+        println!("CPU flamegraph saved to cpu-flamegraph.svg");
+    }
+}
+
+// Hit the `/metrics` endpoint to scrape metrics
+async fn make_single_request() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let body = reqwest::get("http://0.0.0.0:12345/metrics?jobstats=true")
+        .await?
+        .text()
+        .await?;
+
+    Ok(body)
+}
+
+// Use a JoinSet to make `concurrent` requests at a time, waiting for each batch to complete before
+// starting the next batch.
+async fn load_test_concurrent(concurrency: usize, total_requests: usize) -> Duration {
+    let start = Instant::now();
+
+    let mut spawned_requests = 0;
+    let mut successful_requests = 0;
+    let mut failed_requests = 0;
+
+    let mut join_set = JoinSet::new();
+
+    // Initially spawn `concurrency` requests
+    for _ in 0..concurrency {
+        join_set.spawn(async move { make_single_request().await });
+
+        spawned_requests += 1;
+    }
+
+    while let Some(result) = join_set.join_next().await {
+        match result {
+            Ok(Ok(_)) => successful_requests += 1,
+            Ok(Err(_)) => failed_requests += 1,
+            Err(_) => failed_requests += 1,
+        }
+
+        // Immediately spawn a new request if there are more to be made.
+        if spawned_requests < total_requests {
+            join_set.spawn(async move { make_single_request().await });
+
+            spawned_requests += 1;
+        }
+    }
+
+    let elapsed = start.elapsed();
+
+    println!(
+        "Load test completed: {successful_requests} successful, {failed_requests} failed requests in {elapsed:?}.",
+    );
+
+    elapsed
+}


### PR DESCRIPTION
- Change the scrape benchmark to use http requests and the same app that  
we are using in the service. This will make the benchmark closer to
  what we are doing in real life. This also takes into account gzip
  compression and other small details.