### PR TITLE
Add lnetctl global show and health_value

### DIFF
--- a/lustre-collector/src/lib.rs
+++ b/lustre-collector/src/lib.rs
@@ -26,7 +26,9 @@ pub mod types;
 
 pub use crate::error::LustreCollectorError;
 use combine::parser::EasyParser;
-pub use lnetctl_parser::{parse as parse_lnetctl_output, parse_lnetctl_stats};
+pub use lnetctl_parser::{
+    parse as parse_lnetctl_output, parse_lnetctl_global_show, parse_lnetctl_stats,
+};
 pub use node_stats_parsers::{parse_cpustats_output, parse_meminfo_output};
 use std::{io, str};
 pub use types::*;

--- a/lustre-collector/src/lnetctl_parser.rs
+++ b/lustre-collector/src/lnetctl_parser.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     LNetStatGlobal, LustreCollectorError,
-    lnet_exports::LNetStatsStatistics,
+    lnet_exports::{LNetGlobal, LNetStatsStatistics},
     types::{LNetStat, LNetStats, Param, Record, lnet_exports::Net},
 };
 
@@ -32,6 +32,11 @@ pub(crate) fn build_lnet_stats(x: &Net) -> Vec<Record> {
                     nid: y.nid.to_string(),
                     param: Param("drop_count".to_string()),
                     value: y.statistics.drop_count,
+                }),
+                LNetStats::HealthValue(LNetStat {
+                    nid: y.nid.to_string(),
+                    param: Param("health_value".to_string()),
+                    value: y.health_stats.health_value,
                 }),
             ]
         })
@@ -65,6 +70,11 @@ struct LnetStats {
     statistics: Option<LNetStatsStatistics>,
 }
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct LnetGlobalShow {
+    global: Option<LNetGlobal>,
+}
+
 pub(crate) fn build_lnetctl_stats(x: &LNetStatsStatistics) -> Vec<Record> {
     vec![
         Record::LNetStat(LNetStats::SendLength(LNetStatGlobal {
@@ -82,6 +92,15 @@ pub(crate) fn build_lnetctl_stats(x: &LNetStatsStatistics) -> Vec<Record> {
     ]
 }
 
+pub(crate) fn build_lnetctl_global_show(x: &LNetGlobal) -> Vec<Record> {
+    vec![Record::LNetStat(LNetStats::HealthSensitiveValue(
+        LNetStatGlobal {
+            param: Param("health_sensitivity".to_string()),
+            value: x.health_sensitivity,
+        },
+    ))]
+}
+
 pub fn parse_lnetctl_stats(xs: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
     let xs = xs.trim_ascii();
 
@@ -93,6 +112,20 @@ pub fn parse_lnetctl_stats(xs: &[u8]) -> Result<Vec<Record>, LustreCollectorErro
 
     Ok(y.statistics
         .map(|x| build_lnetctl_stats(&x))
+        .unwrap_or_default())
+}
+
+pub fn parse_lnetctl_global_show(xs: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
+    let xs = xs.trim_ascii();
+
+    if xs.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let y: LnetGlobalShow = serde_yaml::from_slice(xs)?;
+
+    Ok(y.global
+        .map(|x| build_lnetctl_global_show(&x))
         .unwrap_or_default())
 }
 
@@ -495,6 +528,30 @@ mod tests {
             recv_length: 17084716480056
             route_length: 0
             drop_length: 568792
+"#,
+        )
+        .unwrap();
+
+        assert_debug_snapshot!(x);
+    }
+
+    #[test]
+    fn test_lnet_global_show() {
+        let x = parse_lnetctl_global_show(
+            br#"global:
+    numa_range: 0
+    max_intf: 200
+    discovery: 1
+    drop_asym_route: 0
+    retry_count: 2
+    transaction_timeout: 150
+    health_sensitivity: 100
+    recovery_interval: 1
+    router_sensitivity: 100
+    lnd_timeout: 49
+    response_tracking: 3
+    recovery_limit: 0
+    max_recovery_ping_interval: 900
 "#,
         )
         .unwrap();

--- a/lustre-collector/src/main.rs
+++ b/lustre-collector/src/main.rs
@@ -4,9 +4,9 @@
 
 use clap::{Arg, ValueEnum, value_parser};
 use lustre_collector::{
-    error::LustreCollectorError, mgs::mgs_fs_parser, parse_lctl_output, parse_lnetctl_output,
-    parse_lnetctl_stats, parse_mgs_fs_output, parse_recovery_status_output, parser,
-    recovery_status_parser, types::Record,
+    error::LustreCollectorError, mgs::mgs_fs_parser, parse_lctl_output, parse_lnetctl_global_show,
+    parse_lnetctl_output, parse_lnetctl_stats, parse_mgs_fs_output, parse_recovery_status_output,
+    parser, recovery_status_parser, types::Record,
 };
 use std::{
     fmt, panic,
@@ -81,6 +81,12 @@ fn get_lnetctl_stats_output() -> Result<Vec<u8>, LustreCollectorError> {
     Ok(r.stdout)
 }
 
+fn get_lnetctl_global_show_output() -> Result<Vec<u8>, LustreCollectorError> {
+    let r = Command::new("lnetctl").arg("global").arg("show").output()?;
+
+    Ok(r.stdout)
+}
+
 fn main() -> ExitCode {
     match run() {
         Ok(()) => ExitCode::SUCCESS,
@@ -136,6 +142,14 @@ fn run() -> Result<(), LustreCollectorError> {
             Ok(lnetctl_stats_record)
         });
 
+    let lnetctl_global_show =
+        thread::spawn(move || -> Result<Vec<Record>, LustreCollectorError> {
+            let lnetctl_global_output = get_lnetctl_global_show_output()?;
+            let lnetctl_global_record = parse_lnetctl_global_show(&lnetctl_global_output)?;
+
+            Ok(lnetctl_global_record)
+        });
+
     let recovery_status_handle =
         thread::spawn(move || -> Result<Vec<Record>, LustreCollectorError> {
             let recovery_status_output = get_recovery_status_output()?;
@@ -172,10 +186,16 @@ fn run() -> Result<(), LustreCollectorError> {
         Err(e) => panic::resume_unwind(e),
     };
 
+    let mut lnetctl_global_show_record = match lnetctl_global_show.join() {
+        Ok(r) => r.unwrap_or_default(),
+        Err(e) => panic::resume_unwind(e),
+    };
+
     lctl_record.append(&mut lnet_record);
     lctl_record.append(&mut mgs_fs_record);
     lctl_record.append(&mut recovery_status_records);
     lctl_record.append(&mut lnetctl_stats_record);
+    lctl_record.append(&mut lnetctl_global_show_record);
 
     let x = match format {
         Format::Json => serde_json::to_string(&lctl_record)?,

--- a/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_export_parse_no_bonding.snap
+++ b/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_export_parse_no_bonding.snap
@@ -1,7 +1,6 @@
 ---
-source: src/lnetctl_parser.rs
+source: lustre-collector/src/lnetctl_parser.rs
 expression: x
-
 ---
 [
     LNetStat(
@@ -38,6 +37,17 @@ expression: x
         ),
     ),
     LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "health_value",
+                ),
+                value: 800,
+            },
+        ),
+    ),
+    LNetStat(
         SendCount(
             LNetStat {
                 nid: "10.36.4.130@tcp",
@@ -67,6 +77,17 @@ expression: x
                     "drop_count",
                 ),
                 value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "10.36.4.130@tcp",
+                param: Param(
+                    "health_value",
+                ),
+                value: 1000,
             },
         ),
     ),

--- a/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_global_show.snap
+++ b/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_global_show.snap
@@ -1,0 +1,16 @@
+---
+source: lustre-collector/src/lnetctl_parser.rs
+expression: x
+---
+[
+    LNetStat(
+        HealthSensitiveValue(
+            LNetStatGlobal {
+                param: Param(
+                    "health_sensitivity",
+                ),
+                value: 100,
+            },
+        ),
+    ),
+]

--- a/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_net_parse.snap
+++ b/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_net_parse.snap
@@ -1,7 +1,6 @@
 ---
-source: src/lnetctl_parser.rs
+source: lustre-collector/src/lnetctl_parser.rs
 expression: x
-
 ---
 [
     LNetStat(
@@ -38,6 +37,17 @@ expression: x
         ),
     ),
     LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "health_value",
+                ),
+                value: 942,
+            },
+        ),
+    ),
+    LNetStat(
         SendCount(
             LNetStat {
                 nid: "10.73.20.11@tcp",
@@ -67,6 +77,17 @@ expression: x
                     "drop_count",
                 ),
                 value: 30,
+            },
+        ),
+    ),
+    LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "10.73.20.11@tcp",
+                param: Param(
+                    "health_value",
+                ),
+                value: 1000,
             },
         ),
     ),

--- a/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_parse2.snap
+++ b/lustre-collector/src/snapshots/lustre_collector__lnetctl_parser__tests__lnet_parse2.snap
@@ -1,7 +1,6 @@
 ---
-source: src/lnetctl_parser.rs
+source: lustre-collector/src/lnetctl_parser.rs
 expression: x
-
 ---
 [
     LNetStat(
@@ -38,6 +37,17 @@ expression: x
         ),
     ),
     LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "0@lo",
+                param: Param(
+                    "health_value",
+                ),
+                value: 0,
+            },
+        ),
+    ),
+    LNetStat(
         SendCount(
             LNetStat {
                 nid: "172.16.0.24@o2ib",
@@ -71,6 +81,17 @@ expression: x
         ),
     ),
     LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "172.16.0.24@o2ib",
+                param: Param(
+                    "health_value",
+                ),
+                value: 1000,
+            },
+        ),
+    ),
+    LNetStat(
         SendCount(
             LNetStat {
                 nid: "172.16.0.28@o2ib",
@@ -100,6 +121,17 @@ expression: x
                     "drop_count",
                 ),
                 value: 0,
+            },
+        ),
+    ),
+    LNetStat(
+        HealthValue(
+            LNetStat {
+                nid: "172.16.0.28@o2ib",
+                param: Param(
+                    "health_value",
+                ),
+                value: 1000,
             },
         ),
     ),

--- a/lustre-collector/src/types.rs
+++ b/lustre-collector/src/types.rs
@@ -167,7 +167,7 @@ pub mod lnet_exports {
     #[derive(serde::Serialize, serde::Deserialize)]
     pub struct HealthStats {
         #[serde(rename = "health value")]
-        health_value: i64,
+        pub health_value: i64,
         interrupts: i64,
         dropped: i64,
         aborted: i64,
@@ -266,6 +266,23 @@ pub mod lnet_exports {
         pub recv_length: i64,
         pub route_length: i64,
         pub drop_length: i64,
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    pub struct LNetGlobal {
+        pub numa_range: i64,
+        pub max_intf: i64,
+        pub discovery: i64,
+        pub drop_asym_route: i64,
+        pub retry_count: i64,
+        pub transaction_timeout: i64,
+        pub health_sensitivity: i64,
+        pub recovery_interval: i64,
+        pub router_sensitivity: i64,
+        pub lnd_timeout: i64,
+        pub response_tracking: i64,
+        pub recovery_limit: i64,
+        pub max_recovery_ping_interval: i64,
     }
 
     #[derive(serde::Serialize, serde::Deserialize)]
@@ -537,6 +554,8 @@ pub enum LNetStats {
     SendCount(LNetStat<i64>),
     RecvCount(LNetStat<i64>),
     DropCount(LNetStat<i64>),
+    HealthValue(LNetStat<i64>),
+    HealthSensitiveValue(LNetStatGlobal<i64>),
     SendLength(LNetStatGlobal<i64>),
     RecvLength(LNetStatGlobal<i64>),
     DropLength(LNetStatGlobal<i64>),

--- a/lustrefs-exporter/src/lib.rs
+++ b/lustrefs-exporter/src/lib.rs
@@ -14,7 +14,8 @@ pub mod service;
 pub mod stats;
 
 use crate::routes::{
-    jobstats_metrics_cmd, lnet_stats_output, lustre_metrics_output, net_show_output,
+    jobstats_metrics_cmd, lnet_global_output, lnet_stats_output, lustre_metrics_output,
+    net_show_output,
 };
 use axum::{
     http::{self, StatusCode},
@@ -122,6 +123,14 @@ pub async fn dump_stats() -> Result<(), Error> {
     let lnetctl_stats_output = lnetctl_stats_output.output().await?;
 
     println!("{}", std::str::from_utf8(&lnetctl_stats_output.stdout)?);
+
+    println!("# Dumping lnetctl global show output");
+
+    let mut lnetctl_global_output = lnet_global_output();
+
+    let lnetctl_global_output = lnetctl_global_output.output().await?;
+
+    println!("{}", std::str::from_utf8(&lnetctl_global_output.stdout)?);
 
     Ok(())
 }
@@ -342,6 +351,7 @@ pub mod tests {
             let otel_metrics = read_metrics_from_snapshot(path);
             let metrics = read_metrics_from_snapshot(&snap_file);
 
+            println!("Comparing {} to {}", path.display(), snap_file.display());
             compare_metrics(&otel_metrics, &metrics);
         });
 

--- a/lustrefs-exporter/src/lnet.rs
+++ b/lustrefs-exporter/src/lnet.rs
@@ -4,7 +4,11 @@
 
 use crate::Family;
 use lustre_collector::{LNetStat, LNetStatGlobal, LNetStats};
-use prometheus_client::{metrics::counter::Counter, registry::Registry};
+use prometheus_client::{
+    metrics::{counter::Counter, gauge::Gauge},
+    registry::Registry,
+};
+use std::sync::atomic::AtomicU64;
 
 #[derive(Debug, Default)]
 pub struct LNetMetrics {
@@ -14,6 +18,8 @@ pub struct LNetMetrics {
     send_bytes_total: Family<Counter<u64>>,
     receive_bytes_total: Family<Counter<u64>>,
     drop_bytes_total: Family<Counter<u64>>,
+    health_value: Family<Gauge<u64, AtomicU64>>,
+    health_sensitivity: Family<Gauge<u64, AtomicU64>>,
 }
 
 impl LNetMetrics {
@@ -53,6 +59,18 @@ impl LNetMetrics {
             "Total number of bytes that have been dropped",
             self.drop_bytes_total.clone(),
         );
+
+        registry.register(
+            "lustre_health_value",
+            "Lustre health value",
+            self.health_value.clone(),
+        );
+
+        registry.register(
+            "lustre_health_sensitivity",
+            "Lustre health sensitivity",
+            self.health_sensitivity.clone(),
+        );
     }
 }
 
@@ -62,6 +80,20 @@ fn record_lnet_stat(stat: &LNetStat<i64>, counter: &mut Family<Counter<u64>>) {
     counter
         .get_or_create(&labels)
         .inc_by(stat.value.try_into().unwrap_or(0));
+}
+
+fn record_lnet_gauge(stat: &LNetStat<i64>, val: &mut Family<Gauge<u64, AtomicU64>>) {
+    let labels = vec![("nid", stat.nid.to_string())];
+
+    val.get_or_create(&labels)
+        .set(stat.value.try_into().unwrap_or(0));
+}
+
+fn record_lnet_global_gauge(stat: &LNetStatGlobal<i64>, val: &mut Family<Gauge<u64, AtomicU64>>) {
+    let labels = vec![];
+
+    val.get_or_create(&labels)
+        .set(stat.value.try_into().unwrap_or(0));
 }
 
 fn record_lnet_stat_global(stat: &LNetStatGlobal<i64>, counter: &mut Family<Counter<u64>>) {
@@ -91,6 +123,12 @@ pub fn build_lnet_stats(x: &LNetStats, lnet: &mut LNetMetrics) {
         }
         LNetStats::DropLength(stat) => {
             record_lnet_stat_global(stat, &mut lnet.drop_bytes_total);
+        }
+        LNetStats::HealthValue(stat) => {
+            record_lnet_gauge(stat, &mut lnet.health_value);
+        }
+        LNetStats::HealthSensitiveValue(stat) => {
+            record_lnet_global_gauge(stat, &mut lnet.health_sensitivity);
         }
     }
 }

--- a/lustrefs-exporter/src/otel_snapshots/lustrefs_exporter__routes__tests__jobstats_with_stderr_output.otelsnap
+++ b/lustrefs-exporter/src/otel_snapshots/lustrefs_exporter__routes__tests__jobstats_with_stderr_output.otelsnap
@@ -602,6 +602,11 @@ lustre_disk_io_total{component="ost",operation="write",size="8192",target="ai400
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped
 # TYPE lustre_drop_bytes_total counter
 lustre_drop_bytes_total{otel_scope_name="lustre"} 4832
+# HELP lustre_health_value Lustre health value.
+# TYPE lustre_health_value gauge
+lustre_health_value{nid="0@lo"} 1000
+lustre_health_value{nid="172.16.0.24@tcp"} 1000
+lustre_health_value{nid="172.16.0.25@tcp"} 1000
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
 lustre_drop_count_total{nid="0@lo",otel_scope_name="lustre"} 4

--- a/lustrefs-exporter/src/otel_snapshots/lustrefs_exporter__routes__tests__metrics_endpoint_is_idempotent.otelsnap
+++ b/lustrefs-exporter/src/otel_snapshots/lustrefs_exporter__routes__tests__metrics_endpoint_is_idempotent.otelsnap
@@ -602,6 +602,11 @@ lustre_disk_io_total{component="ost",operation="write",size="8192",target="ai400
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped
 # TYPE lustre_drop_bytes_total counter
 lustre_drop_bytes_total{otel_scope_name="lustre"} 4832
+# HELP lustre_health_value Lustre health value.
+# TYPE lustre_health_value gauge
+lustre_health_value{nid="0@lo"} 1000
+lustre_health_value{nid="172.16.0.24@tcp"} 1000
+lustre_health_value{nid="172.16.0.25@tcp"} 1000
 # HELP lustre_drop_count_total Total number of messages that have been dropped
 # TYPE lustre_drop_count_total counter
 lustre_drop_count_total{nid="0@lo",otel_scope_name="lustre"} 4

--- a/lustrefs-exporter/src/routes.rs
+++ b/lustrefs-exporter/src/routes.rs
@@ -16,7 +16,9 @@ use axum::{
     response::{IntoResponse, Response},
     routing::get,
 };
-use lustre_collector::{parse_lctl_output, parse_lnetctl_output, parse_lnetctl_stats, parser};
+use lustre_collector::{
+    parse_lctl_output, parse_lnetctl_global_show, parse_lnetctl_output, parse_lnetctl_stats, parser,
+};
 use prometheus_client::{encoding::text::encode, registry::Registry};
 use serde::Deserialize;
 use std::{
@@ -105,6 +107,14 @@ pub fn lnet_stats_output() -> Command {
     let mut cmd = Command::new("lnetctl");
 
     cmd.args(["stats", "show"]).kill_on_drop(true);
+
+    cmd
+}
+
+pub fn lnet_global_output() -> Command {
+    let mut cmd = Command::new("lnetctl");
+
+    cmd.args(["global", "show"]).kill_on_drop(true);
 
     cmd
 }
@@ -218,6 +228,12 @@ pub async fn scrape(Query(params): Query<Params>) -> Result<Response<Body>, Erro
     let mut lnetctl_stats_record = parse_lnetctl_stats(&lnetctl_stats_output.stdout)?;
 
     output.append(&mut lnetctl_stats_record);
+
+    let lnetctl_global_output = lnet_global_output().output().await?;
+
+    let mut lnetctl_global_record = parse_lnetctl_global_show(&lnetctl_global_output.stdout)?;
+
+    output.append(&mut lnetctl_global_record);
 
     // Build and register Lustre metrics
     metrics::build_lustre_stats(&output, &mut opentelemetry_metrics);

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__routes__tests__jobstats_with_stderr_output.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__routes__tests__jobstats_with_stderr_output.snap
@@ -1177,6 +1177,11 @@ lustre_receive_bytes_total{} 254091008
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped.
 # TYPE lustre_drop_bytes_total counter
 lustre_drop_bytes_total{} 4832
+# HELP lustre_health_value Lustre health value.
+# TYPE lustre_health_value gauge
+lustre_health_value{nid="0@lo"} 1000
+lustre_health_value{nid="172.16.0.24@tcp"} 1000
+lustre_health_value{nid="172.16.0.25@tcp"} 1000
 # HELP lustre_read_samples_total Total number of reads that have been recorded.
 # TYPE lustre_read_samples_total counter
 lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 71482249

--- a/lustrefs-exporter/src/snapshots/lustrefs_exporter__routes__tests__metrics_endpoint_is_idempotent.snap
+++ b/lustrefs-exporter/src/snapshots/lustrefs_exporter__routes__tests__metrics_endpoint_is_idempotent.snap
@@ -1177,6 +1177,11 @@ lustre_receive_bytes_total{} 254091008
 # HELP lustre_drop_bytes_total Total number of bytes that have been dropped.
 # TYPE lustre_drop_bytes_total counter
 lustre_drop_bytes_total{} 4832
+# HELP lustre_health_value Lustre health value.
+# TYPE lustre_health_value gauge
+lustre_health_value{nid="0@lo"} 1000
+lustre_health_value{nid="172.16.0.24@tcp"} 1000
+lustre_health_value{nid="172.16.0.25@tcp"} 1000
 # HELP lustre_read_samples_total Total number of reads that have been recorded.
 # TYPE lustre_read_samples_total counter
 lustre_read_samples_total{component="ost",operation="read",target="ai400x2-OST0000"} 71482249


### PR DESCRIPTION
Add:
- health_sensitivity from `lnetctl global show`
- health_value for each NIC

The data is exposed via both lustre-collector and lustrefs-exporter.

Signed-off-by: Feng Lei <flei@ddn.com>