### PR TITLE
Switch serde_yaml to yaml_serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libyaml-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e126dda6f34391ab7b444f9922055facc83c07a910da3eb16f1e4d9c45dc777"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,13 +1365,13 @@ dependencies = [
  "insta",
  "serde",
  "serde_json",
- "serde_yaml",
  "sysinfo",
  "test-case",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -2010,19 +2016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
-dependencies = [
- "indexmap",
- "itoa",
- "ryu",
- "serde",
- "unsafe-libyaml",
-]
-
-[[package]]
 name = "serial_test"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2477,12 +2470,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"
@@ -2971,6 +2958,19 @@ name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yaml_serde"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c7c1b1a6a7c8a6b2741a6c21a4f8918e51899b111cfa08d1288202656e3975"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyaml-rs",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ prometheus-parse = "0.2.5"
 reqwest = "0.11"
 serde = "1"
 serde_json = "1"
-serde_yaml = "0.9"
 serial_test = "3.2"
 sysinfo = "0.29"
 test-case = "3.3"
@@ -42,6 +41,7 @@ tower = "0.5"
 tower-http = "0.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+yaml_serde = "0.10"
 
 [profile.release]
 lto = true

--- a/lustre-collector/Cargo.toml
+++ b/lustre-collector/Cargo.toml
@@ -11,10 +11,10 @@ clap = { workspace = true, features = ["derive"] }
 combine.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-serde_yaml.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+yaml_serde.workspace = true
 
 [dev-dependencies]
 include_dir.workspace = true

--- a/lustre-collector/src/error.rs
+++ b/lustre-collector/src/error.rs
@@ -13,7 +13,7 @@ pub enum LustreCollectorError {
     #[error(transparent)]
     SerdeJsonError(#[from] serde_json::error::Error),
     #[error(transparent)]
-    SerdeYamlError(#[from] serde_yaml::Error),
+    SerdeYamlError(#[from] yaml_serde::Error),
     #[error(transparent)]
     StringStreamError(#[from] StringStreamError),
     #[error(transparent)]

--- a/lustre-collector/src/lnetctl_parser.rs
+++ b/lustre-collector/src/lnetctl_parser.rs
@@ -46,7 +46,7 @@ pub fn parse(xs: &[u8]) -> Result<Vec<Record>, LustreCollectorError> {
         return Ok(vec![]);
     }
 
-    let y: LnetNetStats = serde_yaml::from_slice(xs)?;
+    let y: LnetNetStats = yaml_serde::from_slice(xs)?;
 
     Ok(y.net
         .map(|xs| {
@@ -89,7 +89,7 @@ pub fn parse_lnetctl_stats(xs: &[u8]) -> Result<Vec<Record>, LustreCollectorErro
         return Ok(vec![]);
     }
 
-    let y: LnetStats = serde_yaml::from_slice(xs)?;
+    let y: LnetStats = yaml_serde::from_slice(xs)?;
 
     Ok(y.statistics
         .map(|x| build_lnetctl_stats(&x))

--- a/lustre-collector/src/main.rs
+++ b/lustre-collector/src/main.rs
@@ -179,7 +179,7 @@ fn run() -> Result<(), LustreCollectorError> {
 
     let x = match format {
         Format::Json => serde_json::to_string(&lctl_record)?,
-        Format::Yaml => serde_yaml::to_string(&lctl_record)?,
+        Format::Yaml => yaml_serde::to_string(&lctl_record)?,
     };
 
     println!("{x}");


### PR DESCRIPTION
serde_yaml has been depricated as unsupported.
yaml_serde seems to be the successor package.