### PR TITLE
Release to 12.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,7 +1356,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "lustre_collector"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "clap",
  "combine",
@@ -1376,7 +1376,7 @@ dependencies = [
 
 [[package]]
 name = "lustrefs-exporter"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "axum",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "3"
 authors = ["EMF Team <emf@whamcloud.com>"]
 edition = "2024"
 license = "MIT"
-version = "0.12.3"
+version = "0.12.4"
 
 [workspace.lints.rust]
 unreachable_pub = "deny"

--- a/lustrefs-exporter/debian/changelog
+++ b/lustrefs-exporter/debian/changelog
@@ -1,3 +1,10 @@
+prometheus-lustrefs-exporter (0.12.4-0.1) unstable; urgency=medium
+
+  * Add opsize dimension to lustre_io_time_milliseconds
+  * Update brw_stats fixtures for log2 disk I/Os in flight
+
+ -- EMF Team <emf@whamcloud.com>  Tue, 02 Jun 2026 17:00:00 +0200
+
 prometheus-lustrefs-exporter (0.12.3-0.1) unstable; urgency=medium
 
   * Fix parsing recovery status for multiple targets

--- a/lustrefs-exporter/lustrefs_exporter.spec
+++ b/lustrefs-exporter/lustrefs_exporter.spec
@@ -1,5 +1,5 @@
 Name:           lustrefs_exporter
-Version:        0.12.3
+Version:        0.12.4
 Release:        1%{?dist}
 Summary:        prometheus exporter for lustre
 License:        MIT


### PR DESCRIPTION
Run for RPM build: https://github.com/whamcloud/lustrefs-exporter/actions/runs/26811943416 

This pull request updates the version of the LustreFS Prometheus exporter to 0.12.4 and documents recent changes. The main updates are version bumps across packaging files and changelog entries describing new features and fixture updates.

Version and packaging updates:

* Bumped the crate version in `Cargo.toml` from 0.12.3 to 0.12.4.
* Updated the RPM spec file `lustrefs_exporter.spec` to reflect version 0.12.4.

Changelog updates:

* Added a new changelog entry in `debian/changelog` for version 0.12.4, noting the addition of the `opsize` dimension to the `lustre_io_time_milliseconds` metric and updates to `brw_stats` fixtures for log2 disk I/Os in flight.